### PR TITLE
Split Kafka admin & producer in prep for adding consumer.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
     stages {
         stage('Compile') {
             steps {
-                sh 'sbt compile'
+                sh 'sbt Compile/compile Test/compile'
             }
         }
         stage('Test') {

--- a/manager/src/main/scala/org/broadinstitute/transporter/info/InfoController.scala
+++ b/manager/src/main/scala/org/broadinstitute/transporter/info/InfoController.scala
@@ -3,7 +3,7 @@ package org.broadinstitute.transporter.info
 import cats.effect.{ContextShift, IO}
 import cats.implicits._
 import org.broadinstitute.transporter.db.DbClient
-import org.broadinstitute.transporter.kafka.KafkaClient
+import org.broadinstitute.transporter.kafka.AdminClient
 
 /**
   * Component responsible for handling status and version requests.
@@ -15,7 +15,7 @@ import org.broadinstitute.transporter.kafka.KafkaClient
   * @param cs proof of the ability to shift IO-wrapped computations
   *           onto other threads
   */
-class InfoController(appVersion: String, dbClient: DbClient, kafkaClient: KafkaClient)(
+class InfoController(appVersion: String, dbClient: DbClient, kafkaClient: AdminClient)(
   implicit cs: ContextShift[IO]
 ) {
 

--- a/manager/src/main/scala/org/broadinstitute/transporter/kafka/AdminClient.scala
+++ b/manager/src/main/scala/org/broadinstitute/transporter/kafka/AdminClient.scala
@@ -12,8 +12,10 @@ import scala.concurrent.ExecutionContext
 import scala.collection.JavaConverters._
 
 /**
-  * Client responsible for managing topic-level operations in
-  * Transporter's backing Kafka cluster.
+  * Client responsible for managing "admin" operations in Transporter's Kafka cluster.
+  *
+  * Admin ops include querying cluster-level state, creating/modifying/deleting topics,
+  * and settings ACLs (though we don't handle that yet).
   */
 trait AdminClient {
 
@@ -88,8 +90,7 @@ object AdminClient {
     *   2. Automatically clean up the underlying clients and their
     *      pools on shutdown
     *
-    * @param config settings for the underlying Kafka clients powering
-    *               our client
+    * @param config settings for the underlying Kafka client
     * @param blockingEc execution context which should run the blocking I/O
     *                   required to set up / tear down the client
     * @param cs proof of the ability to shift IO-wrapped computations
@@ -117,13 +118,12 @@ object AdminClient {
   }
 
   /**
-    * Concrete implementation of our Kafka admin client used by mainline code.
+    * Concrete implementation of our admin client used by mainline code.
     *
     * Partly a copy-paste of fs2-kafka's AdminClient, which doesn't support all
     * the functionality we need.
     *
-    * @param adminClient "raw" Java client which actually knows how to
-    *                    interact with Kafka
+    * @param adminClient client which can execute "raw" Kafka requests
     * @param topicConfig configuration to apply to all topics created
     *                    by the client
     * @param cs proof of the ability to shift IO-wrapped computations

--- a/manager/src/main/scala/org/broadinstitute/transporter/kafka/AdminClient.scala
+++ b/manager/src/main/scala/org/broadinstitute/transporter/kafka/AdminClient.scala
@@ -1,23 +1,21 @@
 package org.broadinstitute.transporter.kafka
 
-import java.util.UUID
 import java.util.concurrent.{CancellationException, CompletionException}
 
 import cats.effect._
 import cats.implicits._
-import fs2.kafka.{KafkaProducer, ProducerMessage, ProducerRecord, Serializer}
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
-import io.circe.Json
-import org.apache.kafka.clients.admin.{AdminClient, NewTopic}
+import org.apache.kafka.clients.admin.{AdminClient => JAdminClient, NewTopic}
 import org.apache.kafka.common.KafkaFuture
 
 import scala.concurrent.ExecutionContext
 import scala.collection.JavaConverters._
 
 /**
-  * Client responsible for managing communication with Transporter's backing Kafka cluster.
+  * Client responsible for managing topic-level operations in
+  * Transporter's backing Kafka cluster.
   */
-trait KafkaClient {
+trait AdminClient {
 
   /** Check if the client can interact with the backing cluster. */
   def checkReady: IO[Boolean]
@@ -35,12 +33,9 @@ trait KafkaClient {
 
   /** Check that the given topics exist in Kafka. */
   def topicsExist(topicNames: String*): IO[Boolean]
-
-  /** Submit a batch of messages to a topic. */
-  def submit(topic: String, messages: List[(UUID, Json)]): IO[Unit]
 }
 
-object KafkaClient {
+object AdminClient {
 
   /**
     * Extension methods for Kafka's bespoke Future implementation.
@@ -86,9 +81,6 @@ object KafkaClient {
         s"Failed to create topics: ${failures.map(_._1).mkString(", ")}"
       )
 
-  /** Kafka-specific serializer for JSON messages. */
-  private val jsonSerializer = Serializer.string.contramap[Json](_.noSpaces)
-
   /**
     * Construct a Kafka client, wrapped in logic which will:
     *   1. Automatically set up underlying Kafka client instances
@@ -105,20 +97,18 @@ object KafkaClient {
     */
   def resource(config: KafkaConfig, blockingEc: ExecutionContext)(
     implicit cs: ContextShift[IO]
-  ): Resource[IO, KafkaClient] =
-    (adminResource(config, blockingEc), producerResource(config)).tupled.map {
-      case (admin, producer) => new Impl(admin, producer, config.topicDefaults)
-    }
+  ): Resource[IO, AdminClient] =
+    adminResource(config, blockingEc).map(new Impl(_, config.topicDefaults))
 
   /** Construct a Kafka admin client, wrapped in setup and teardown logic. */
   private[kafka] def adminResource(config: KafkaConfig, blockingEc: ExecutionContext)(
     implicit cs: ContextShift[IO]
-  ): Resource[IO, AdminClient] = {
+  ): Resource[IO, JAdminClient] = {
     val settings = config.adminSettings
     val initClient = cs.evalOn(blockingEc) {
       settings.adminClientFactory.create[IO](settings)
     }
-    val closeClient = (client: AdminClient) =>
+    val closeClient = (client: JAdminClient) =>
       cs.evalOn(blockingEc)(IO.delay {
         client.close(settings.closeTimeout.length, settings.closeTimeout.unit)
       })
@@ -126,33 +116,24 @@ object KafkaClient {
     Resource.make(initClient)(closeClient)
   }
 
-  /** Construct a Kafka producer, wrapper in setup and teardown logic. */
-  private[kafka] def producerResource(config: KafkaConfig)(
-    implicit cs: ContextShift[IO]
-  ) =
-    fs2.kafka
-      .producerResource[IO]
-      .using(config.producerSettings(Serializer.uuid, jsonSerializer))
-
   /**
     * Concrete implementation of our Kafka admin client used by mainline code.
     *
     * Partly a copy-paste of fs2-kafka's AdminClient, which doesn't support all
     * the functionality we need.
     *
-    * @param adminClient "raw" Kafka client which actually knows how to
-    *                    interact with the backing cluster
+    * @param adminClient "raw" Java client which actually knows how to
+    *                    interact with Kafka
     * @param topicConfig configuration to apply to all topics created
     *                    by the client
     * @param cs proof of the ability to shift IO-wrapped computations
     *           onto other threads
     */
   private[kafka] class Impl(
-    adminClient: AdminClient,
-    producer: KafkaProducer[IO, UUID, Json],
+    adminClient: JAdminClient,
     topicConfig: TopicConfig
   )(implicit cs: ContextShift[IO])
-      extends KafkaClient {
+      extends AdminClient {
 
     private val logger = Slf4jLogger.getLogger[IO]
 
@@ -192,21 +173,6 @@ object KafkaClient {
       } yield {
         topicNames.toSet.subsetOf(existingTopics)
       }
-
-    override def submit(topic: String, messages: List[(UUID, Json)]): IO[Unit] = {
-      val records = messages.map {
-        case (id, value) => ProducerRecord(topic, id, value)
-      }
-
-      for {
-        _ <- logger.debug(s"Submitting ${messages.length} records to Kafka topic $topic")
-        ackIO <- producer.producePassthrough(ProducerMessage(records))
-        _ <- logger.debug(s"Waiting for Kafka to acknowledge submission...")
-        _ <- ackIO
-      } yield {
-        ()
-      }
-    }
 
     /**
       * Get the list of all non-internal topics in Transporter's backing Kafka cluster.

--- a/manager/src/main/scala/org/broadinstitute/transporter/kafka/KafkaConfig.scala
+++ b/manager/src/main/scala/org/broadinstitute/transporter/kafka/KafkaConfig.scala
@@ -27,6 +27,7 @@ case class KafkaConfig(
     * which isn't acceptable for our use-case.
     */
   def producerSettings[K, V](
+    implicit
     keySerializer: Serializer[K],
     valueSerializer: Serializer[V]
   ): ProducerSettings[K, V] =

--- a/manager/src/main/scala/org/broadinstitute/transporter/kafka/KafkaProducer.scala
+++ b/manager/src/main/scala/org/broadinstitute/transporter/kafka/KafkaProducer.scala
@@ -1,0 +1,39 @@
+package org.broadinstitute.transporter.kafka
+
+import cats.effect.{ContextShift, IO, Resource}
+import cats.implicits._
+import fs2.kafka.{ProducerMessage, ProducerRecord, Serializer, KafkaProducer => KProducer}
+import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
+
+trait KafkaProducer[K, V] {
+
+  /** Submit a batch of messages to a topic. */
+  def submit(topic: String, messages: List[(K, V)]): IO[Unit]
+}
+
+object KafkaProducer {
+
+  def resource[K: Serializer, V: Serializer](config: KafkaConfig)(
+    implicit cs: ContextShift[IO]
+  ): Resource[IO, KafkaProducer[K, V]] =
+    fs2.kafka.producerResource[IO].using(config.producerSettings[K, V]).map(new Impl(_))
+
+  private[kafka] class Impl[K, V](producer: KProducer[IO, K, V])
+      extends KafkaProducer[K, V] {
+
+    private val logger = Slf4jLogger.getLogger[IO]
+
+    override def submit(topic: String, messages: List[(K, V)]): IO[Unit] = {
+      val records = messages.map {
+        case (id, value) => ProducerRecord(topic, id, value)
+      }
+
+      for {
+        _ <- logger.info(s"Submitting ${messages.length} records to Kafka topic $topic")
+        ackIO <- producer.producePassthrough(ProducerMessage(records))
+        _ <- logger.debug(s"Waiting for Kafka to acknowledge submission...")
+        _ <- ackIO
+      } yield ()
+    }
+  }
+}

--- a/manager/src/main/scala/org/broadinstitute/transporter/kafka/KafkaProducer.scala
+++ b/manager/src/main/scala/org/broadinstitute/transporter/kafka/KafkaProducer.scala
@@ -5,19 +5,46 @@ import cats.implicits._
 import fs2.kafka.{ProducerMessage, ProducerRecord, Serializer, KafkaProducer => KProducer}
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 
+/**
+  * Client responsible for pushing messages into Kafka topics.
+  *
+  * Raw Kafka producer instances are configured to work with specific
+  * key/value types, so this class does the same.
+  *
+  * @tparam K the type of keys which should be pushed to Kafka by this producer
+  * @tparam V the type of values which should be pushed to Kafka by this producer
+  */
 trait KafkaProducer[K, V] {
 
-  /** Submit a batch of messages to a topic. */
+  /**
+    * Submit a batch of messages to a topic.
+    *
+    * The returned `IO` will only complete when the produced
+    * messages have been acknowledged by the Kafka cluster.
+    */
   def submit(topic: String, messages: List[(K, V)]): IO[Unit]
 }
 
 object KafkaProducer {
 
+  /**
+    * Construct a producer wrapped in logic to set up / tear down
+    * the threading infrastructure required by the underlying Java client.
+    *
+    * @param config settings for the underlying Kafka client
+    * @param cs proof of the ability to shift IO-wrapped computations
+    *           onto other threads
+    */
   def resource[K: Serializer, V: Serializer](config: KafkaConfig)(
     implicit cs: ContextShift[IO]
   ): Resource[IO, KafkaProducer[K, V]] =
     fs2.kafka.producerResource[IO].using(config.producerSettings[K, V]).map(new Impl(_))
 
+  /**
+    * Concrete implementation of our producer used by mainline code.
+    *
+    * @param producer client which can push "raw" messages to Kafka
+    */
   private[kafka] class Impl[K, V](producer: KProducer[IO, K, V])
       extends KafkaProducer[K, V] {
 

--- a/manager/src/main/scala/org/broadinstitute/transporter/queue/QueueController.scala
+++ b/manager/src/main/scala/org/broadinstitute/transporter/queue/QueueController.scala
@@ -4,7 +4,7 @@ import cats.effect.{ExitCase, IO}
 import cats.implicits._
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 import org.broadinstitute.transporter.db.DbClient
-import org.broadinstitute.transporter.kafka.KafkaClient
+import org.broadinstitute.transporter.kafka.AdminClient
 
 /** Component responsible for handling all queue-related web requests. */
 trait QueueController {
@@ -42,7 +42,7 @@ trait QueueController {
 object QueueController {
 
   // Pseudo-constructor for the Impl subclass.
-  def apply(dbClient: DbClient, kafkaClient: KafkaClient): QueueController =
+  def apply(dbClient: DbClient, kafkaClient: AdminClient): QueueController =
     new Impl(dbClient, kafkaClient)
 
   /** Exception used to mark when a user attempts to create a queue that already exists. */
@@ -55,7 +55,7 @@ object QueueController {
     * @param dbClient client which can interact with Transporter's DB
     * @param kafkaClient client which can interact with Transporter's Kafka cluster
     */
-  private[queue] class Impl(dbClient: DbClient, kafkaClient: KafkaClient)
+  private[queue] class Impl(dbClient: DbClient, kafkaClient: AdminClient)
       extends QueueController {
 
     private val logger = Slf4jLogger.getLogger[IO]

--- a/manager/src/test/scala/org/broadinstitute/transporter/info/InfoControllerSpec.scala
+++ b/manager/src/test/scala/org/broadinstitute/transporter/info/InfoControllerSpec.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.transporter.info
 
 import cats.effect.{ContextShift, IO}
 import org.broadinstitute.transporter.db.DbClient
-import org.broadinstitute.transporter.kafka.KafkaClient
+import org.broadinstitute.transporter.kafka.AdminClient
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FlatSpec, Matchers}
 
@@ -13,7 +13,7 @@ class InfoControllerSpec extends FlatSpec with Matchers with MockFactory {
   private val version = "0.0.0-TEST"
 
   private val db = mock[DbClient]
-  private val kafka = mock[KafkaClient]
+  private val kafka = mock[AdminClient]
 
   implicit val cs: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
 

--- a/manager/src/test/scala/org/broadinstitute/transporter/kafka/BaseKafkaSpec.scala
+++ b/manager/src/test/scala/org/broadinstitute/transporter/kafka/BaseKafkaSpec.scala
@@ -30,8 +30,8 @@ trait BaseKafkaSpec extends FlatSpec with Matchers with EmbeddedKafka {
     timingConfig
   )
 
-  protected def withKafka[T](body: KafkaConfig => T): T =
+  protected def withKafka[T](body: (KafkaConfig, EmbeddedKafkaConfig) => T): T =
     withRunningKafkaOnFoundPort(baseConfig) { actualConfig =>
-      body(appConfig(actualConfig))
+      body(appConfig(actualConfig), actualConfig)
     }
 }

--- a/manager/src/test/scala/org/broadinstitute/transporter/kafka/BaseKafkaSpec.scala
+++ b/manager/src/test/scala/org/broadinstitute/transporter/kafka/BaseKafkaSpec.scala
@@ -1,0 +1,37 @@
+package org.broadinstitute.transporter.kafka
+
+import cats.effect.{ContextShift, IO}
+import net.manub.embeddedkafka.{EmbeddedKafka, EmbeddedKafkaConfig}
+import org.scalatest.{FlatSpec, Matchers}
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+
+trait BaseKafkaSpec extends FlatSpec with Matchers with EmbeddedKafka {
+
+  protected implicit val cs: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
+
+  protected val topicConfig = TopicConfig(
+    partitions = 1,
+    replicationFactor = 1
+  )
+
+  protected val timingConfig = TimeoutConfig(
+    requestTimeout = 2.seconds,
+    closeTimeout = 1.second
+  )
+
+  private val baseConfig = EmbeddedKafkaConfig(kafkaPort = 0, zooKeeperPort = 0)
+
+  protected def appConfig(embeddedConfig: EmbeddedKafkaConfig) = KafkaConfig(
+    List(s"localhost:${embeddedConfig.kafkaPort}"),
+    "kafka-test",
+    topicConfig,
+    timingConfig
+  )
+
+  protected def withKafka[T](body: KafkaConfig => T): T =
+    withRunningKafkaOnFoundPort(baseConfig) { actualConfig =>
+      body(appConfig(actualConfig))
+    }
+}

--- a/manager/src/test/scala/org/broadinstitute/transporter/kafka/KafkaProducerSpec.scala
+++ b/manager/src/test/scala/org/broadinstitute/transporter/kafka/KafkaProducerSpec.scala
@@ -11,23 +11,27 @@ class KafkaProducerSpec extends BaseKafkaSpec {
   it should "submit messages" in {
     val topic = "the-topic"
 
-    implicit val keySerializer: Serializer[Int] = Serializer.int
-    implicit val keyDeserializer: Deserializer[Int] =
-      Deserializer.int.map(_.valueOr(throw _))
-    implicit val valSerializer: Serializer[String] = Serializer.string
-    implicit val valDeserializer: Deserializer[String] = Deserializer.string
+    implicit val ks: Serializer[Int] = Serializer.int
+    implicit val vs: Serializer[String] = Serializer.string
+
+    val kd: Deserializer[Int] = Deserializer.int.map(_.valueOr(throw _))
+    val vd: Deserializer[String] = Deserializer.string
 
     val messages = List(1 -> "foo", 2 -> "bar", 3 -> "baz")
 
-    val published = withKafka { config =>
+    val published = withKafka { (config, embeddedConfig) =>
       KafkaProducer
         .resource[Int, String](config)
         .use { producer =>
           for {
-            _ <- IO.delay(createCustomTopic(topic))
+            _ <- IO.delay(createCustomTopic(topic)(embeddedConfig))
             _ <- producer.submit(topic, messages)
             consumed <- IO.delay {
-              consumeNumberKeyedMessagesFrom[Int, String](topic, messages.length)
+              consumeNumberKeyedMessagesFrom(topic, messages.length)(
+                embeddedConfig,
+                kd,
+                vd
+              )
             }
           } yield {
             consumed

--- a/manager/src/test/scala/org/broadinstitute/transporter/kafka/KafkaProducerSpec.scala
+++ b/manager/src/test/scala/org/broadinstitute/transporter/kafka/KafkaProducerSpec.scala
@@ -1,39 +1,10 @@
 package org.broadinstitute.transporter.kafka
 
-import cats.effect.{ContextShift, IO, Resource}
+import cats.effect.IO
 import cats.implicits._
 import fs2.kafka.{Deserializer, Serializer}
-import net.manub.embeddedkafka.{EmbeddedKafka, EmbeddedKafkaConfig}
-import org.scalatest.{FlatSpec, Matchers}
 
-import scala.concurrent.ExecutionContext
-import scala.concurrent.duration._
-
-class KafkaProducerSpec extends FlatSpec with Matchers with EmbeddedKafka {
-
-  private implicit val cs: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
-
-  private val topicConfig = TopicConfig(
-    partitions = 1,
-    replicationFactor = 1
-  )
-  private val timeouts = TimeoutConfig(
-    requestTimeout = 2.seconds,
-    closeTimeout = 1.seconds,
-    metadataTtl = 500.millis
-  )
-  private val baseConfig = EmbeddedKafkaConfig(kafkaPort = 0, zooKeeperPort = 0)
-  private def config(embeddedConfig: EmbeddedKafkaConfig) = KafkaConfig(
-    List(s"localhost:${embeddedConfig.kafkaPort}"),
-    "test-producer",
-    topicConfig,
-    timeouts
-  )
-
-  private def producerResource[K: Serializer, V: Serializer](
-    embeddedConfig: EmbeddedKafkaConfig
-  ): Resource[IO, KafkaProducer[K, V]] =
-    KafkaProducer.resource[K, V](config(embeddedConfig))
+class KafkaProducerSpec extends BaseKafkaSpec {
 
   behavior of "KafkaProducer"
 
@@ -48,18 +19,21 @@ class KafkaProducerSpec extends FlatSpec with Matchers with EmbeddedKafka {
 
     val messages = List(1 -> "foo", 2 -> "bar", 3 -> "baz")
 
-    val published = withRunningKafkaOnFoundPort(baseConfig) { implicit actualConfig =>
-      producerResource[Int, String](actualConfig).use { producer =>
-        for {
-          _ <- IO.delay(createCustomTopic(topic))
-          _ <- producer.submit(topic, messages)
-          consumed <- IO.delay {
-            consumeNumberKeyedMessagesFrom[Int, String](topic, messages.length)
+    val published = withKafka { config =>
+      KafkaProducer
+        .resource[Int, String](config)
+        .use { producer =>
+          for {
+            _ <- IO.delay(createCustomTopic(topic))
+            _ <- producer.submit(topic, messages)
+            consumed <- IO.delay {
+              consumeNumberKeyedMessagesFrom[Int, String](topic, messages.length)
+            }
+          } yield {
+            consumed
           }
-        } yield {
-          consumed
         }
-      }.unsafeRunSync()
+        .unsafeRunSync()
     }
 
     published shouldBe messages

--- a/manager/src/test/scala/org/broadinstitute/transporter/kafka/KafkaProducerSpec.scala
+++ b/manager/src/test/scala/org/broadinstitute/transporter/kafka/KafkaProducerSpec.scala
@@ -1,0 +1,67 @@
+package org.broadinstitute.transporter.kafka
+
+import cats.effect.{ContextShift, IO, Resource}
+import cats.implicits._
+import fs2.kafka.{Deserializer, Serializer}
+import net.manub.embeddedkafka.{EmbeddedKafka, EmbeddedKafkaConfig}
+import org.scalatest.{FlatSpec, Matchers}
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+
+class KafkaProducerSpec extends FlatSpec with Matchers with EmbeddedKafka {
+
+  private implicit val cs: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
+
+  private val topicConfig = TopicConfig(
+    partitions = 1,
+    replicationFactor = 1
+  )
+  private val timeouts = TimeoutConfig(
+    requestTimeout = 2.seconds,
+    closeTimeout = 1.seconds,
+    metadataTtl = 500.millis
+  )
+  private val baseConfig = EmbeddedKafkaConfig(kafkaPort = 0, zooKeeperPort = 0)
+  private def config(embeddedConfig: EmbeddedKafkaConfig) = KafkaConfig(
+    List(s"localhost:${embeddedConfig.kafkaPort}"),
+    "test-producer",
+    topicConfig,
+    timeouts
+  )
+
+  private def producerResource[K: Serializer, V: Serializer](
+    embeddedConfig: EmbeddedKafkaConfig
+  ): Resource[IO, KafkaProducer[K, V]] =
+    KafkaProducer.resource[K, V](config(embeddedConfig))
+
+  behavior of "KafkaProducer"
+
+  it should "submit messages" in {
+    val topic = "the-topic"
+
+    implicit val keySerializer: Serializer[Int] = Serializer.int
+    implicit val keyDeserializer: Deserializer[Int] =
+      Deserializer.int.map(_.valueOr(throw _))
+    implicit val valSerializer: Serializer[String] = Serializer.string
+    implicit val valDeserializer: Deserializer[String] = Deserializer.string
+
+    val messages = List(1 -> "foo", 2 -> "bar", 3 -> "baz")
+
+    val published = withRunningKafkaOnFoundPort(baseConfig) { implicit actualConfig =>
+      producerResource[Int, String](actualConfig).use { producer =>
+        for {
+          _ <- IO.delay(createCustomTopic(topic))
+          _ <- producer.submit(topic, messages)
+          consumed <- IO.delay {
+            consumeNumberKeyedMessagesFrom[Int, String](topic, messages.length)
+          }
+        } yield {
+          consumed
+        }
+      }.unsafeRunSync()
+    }
+
+    published shouldBe messages
+  }
+}

--- a/manager/src/test/scala/org/broadinstitute/transporter/queue/QueueControllerSpec.scala
+++ b/manager/src/test/scala/org/broadinstitute/transporter/queue/QueueControllerSpec.scala
@@ -5,7 +5,7 @@ import java.util.UUID
 import cats.effect.IO
 import io.circe.Json
 import org.broadinstitute.transporter.db.DbClient
-import org.broadinstitute.transporter.kafka.KafkaClient
+import org.broadinstitute.transporter.kafka.AdminClient
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{EitherValues, FlatSpec, Matchers}
 
@@ -16,7 +16,7 @@ class QueueControllerSpec
     with EitherValues {
 
   private val db = mock[DbClient]
-  private val kafka = mock[KafkaClient]
+  private val kafka = mock[AdminClient]
 
   private def controller = new QueueController.Impl(db, kafka)
 

--- a/manager/src/test/scala/org/broadinstitute/transporter/transfer/TransferControllerSpec.scala
+++ b/manager/src/test/scala/org/broadinstitute/transporter/transfer/TransferControllerSpec.scala
@@ -3,9 +3,10 @@ package org.broadinstitute.transporter.transfer
 import java.util.UUID
 
 import cats.effect.IO
+import io.circe.Json
 import io.circe.literal._
 import org.broadinstitute.transporter.db.DbClient
-import org.broadinstitute.transporter.kafka.KafkaClient
+import org.broadinstitute.transporter.kafka.KafkaProducer
 import org.broadinstitute.transporter.queue.{QueueController, QueueSchema}
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{EitherValues, FlatSpec, Matchers}
@@ -18,7 +19,7 @@ class TransferControllerSpec
 
   private val db = mock[DbClient]
   private val queueController = mock[QueueController]
-  private val kafka = mock[KafkaClient]
+  private val kafka = mock[KafkaProducer[UUID, Json]]
 
   private val queueName = "queue"
   private val queueId = UUID.randomUUID()


### PR DESCRIPTION
Trying to get out of the habit of large PRs!

I was going to add consumer functionality to the existing `KafkaClient`, but it really doesn't make sense to bundle all of that functionality together. Splitting up the existing admin & producer logic as a start towards a better structure.