### PR TITLE
DSPDC-119 Rough AWS->GCP agent

### DIFF
--- a/agents/aws-to-gcp/README.md
+++ b/agents/aws-to-gcp/README.md
@@ -1,0 +1,21 @@
+# Transporter AWS->GCP Agent
+Transporter agent which copies files from AWS to GCP.
+
+## Expected schema
+Use this JSON schema to initialize Transporter queues for this agent:
+```json
+{
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "type": "object",
+  "properties": {
+    "s3Bucket": { "type": "string" },
+    "s3Path": { "type": "string" },
+    "gcsBucket": { "type": "string" },
+    "gcsPath": { "type": "string" },
+    "expectedSize": { "type": "integer" },
+    "expectedMd5": { "type": "string", "pattern": "[0-9a-fA-F]+" }
+  },
+  "required": ["s3Bucket", "s3Path", "gcsBucket", "gcsPath"],
+  "additionalProperties": false
+}
+```

--- a/agents/aws-to-gcp/src/main/resources/reference.conf
+++ b/agents/aws-to-gcp/src/main/resources/reference.conf
@@ -1,0 +1,17 @@
+org.broadinstitute.transporter {
+  kafka.application-id: "transporter-aws-to-gcp-agent"
+
+  runner-config {
+    aws {
+      # Pull from the environment for local development.
+      access-key-id: ${AWS_ACCESS_KEY_ID}
+      secret-access-key: ${AWS_SECRET_ACCESS_KEY}
+      region: "us-west-2"
+    }
+
+    gcp {
+      # Fill this in to use non-default credentials.
+      service-account-json: null
+    }
+  }
+}

--- a/agents/aws-to-gcp/src/main/scala/org/broadinstitute/transporter/AwsToGcpAgent.scala
+++ b/agents/aws-to-gcp/src/main/scala/org/broadinstitute/transporter/AwsToGcpAgent.scala
@@ -1,5 +1,7 @@
 package org.broadinstitute.transporter
 
+import java.util.concurrent.{ExecutorService, Executors}
+
 import cats.effect.{IO, Resource}
 import cats.implicits._
 import com.google.cloud.storage.Storage
@@ -11,7 +13,20 @@ import org.broadinstitute.transporter.transfer.{
 }
 import software.amazon.awssdk.services.s3.S3Client
 
+import scala.concurrent.ExecutionContext
+
+/**
+  * Transporter agent which can copy files from S3 to GCS, optionally
+  * enforcing an expected length/md5 in the process.
+  */
 object AwsToGcpAgent extends TransporterAgent[RunnerConfig, AwsToGcpRequest] {
+
+  /** Build a resource wrapping a single-threaded execution context. */
+  private def singleThreadedEc: Resource[IO, ExecutionContext] = {
+    val allocate = IO.delay(Executors.newSingleThreadExecutor())
+    val free = (es: ExecutorService) => IO.delay(es.shutdown())
+    Resource.make(allocate)(free).map(ExecutionContext.fromExecutor)
+  }
 
   override def runnerResource(
     config: RunnerConfig
@@ -19,8 +34,12 @@ object AwsToGcpAgent extends TransporterAgent[RunnerConfig, AwsToGcpRequest] {
     val create = (config.aws.toClient, config.gcp.toClient).tupled
     val close = (clients: (S3Client, Storage)) => IO.delay(clients._1.close())
 
-    Resource.make(create)(close).map {
-      case (s3, gcs) => new AwsToGcpRunner(s3, gcs)
+    for {
+      (s3, gcs) <- Resource.make(create)(close)
+      s3Ec <- singleThreadedEc
+      gcsEc <- singleThreadedEc
+    } yield {
+      new AwsToGcpRunner(s3, s3Ec, gcs, gcsEc)
     }
   }
 }

--- a/agents/aws-to-gcp/src/main/scala/org/broadinstitute/transporter/AwsToGcpAgent.scala
+++ b/agents/aws-to-gcp/src/main/scala/org/broadinstitute/transporter/AwsToGcpAgent.scala
@@ -1,0 +1,26 @@
+package org.broadinstitute.transporter
+
+import cats.effect.{IO, Resource}
+import cats.implicits._
+import com.google.cloud.storage.Storage
+import org.broadinstitute.transporter.config.RunnerConfig
+import org.broadinstitute.transporter.transfer.{
+  AwsToGcpRequest,
+  AwsToGcpRunner,
+  TransferRunner
+}
+import software.amazon.awssdk.services.s3.S3Client
+
+object AwsToGcpAgent extends TransporterAgent[RunnerConfig, AwsToGcpRequest] {
+
+  override def runnerResource(
+    config: RunnerConfig
+  ): Resource[IO, TransferRunner[AwsToGcpRequest]] = {
+    val create = (config.aws.toClient, config.gcp.toClient).tupled
+    val close = (clients: (S3Client, Storage)) => IO.delay(clients._1.close())
+
+    Resource.make(create)(close).map {
+      case (s3, gcs) => new AwsToGcpRunner(s3, gcs)
+    }
+  }
+}

--- a/agents/aws-to-gcp/src/main/scala/org/broadinstitute/transporter/config/AwsConfig.scala
+++ b/agents/aws-to-gcp/src/main/scala/org/broadinstitute/transporter/config/AwsConfig.scala
@@ -18,12 +18,14 @@ import software.amazon.awssdk.services.s3.S3Client
 
 import scala.collection.JavaConverters._
 
+/** Configuration determining how the AWS->GCP agent should connect to S3. */
 case class AwsConfig(
   accessKeyId: String,
   secretAccessKey: String,
   region: Region
 ) {
 
+  /** Build an S3 client using the auth configuration from this object. */
   def toClient: IO[S3Client] = IO.delay {
     import RetryConstants._
 
@@ -59,6 +61,8 @@ case class AwsConfig(
 }
 
 object AwsConfig {
+
+  /** Convenience converter from arbitrary strings into AWS Regions. */
   implicit val regionReader: ConfigReader[Region] =
     ConfigReader.stringConfigReader.emap { str =>
       Region

--- a/agents/aws-to-gcp/src/main/scala/org/broadinstitute/transporter/config/AwsConfig.scala
+++ b/agents/aws-to-gcp/src/main/scala/org/broadinstitute/transporter/config/AwsConfig.scala
@@ -1,0 +1,72 @@
+package org.broadinstitute.transporter.config
+
+import java.time.Duration
+
+import cats.effect.IO
+import pureconfig.ConfigReader
+import pureconfig.error.CannotConvert
+import pureconfig.generic.semiauto.deriveReader
+import software.amazon.awssdk.auth.credentials.{
+  AwsBasicCredentials,
+  StaticCredentialsProvider
+}
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration
+import software.amazon.awssdk.core.retry.RetryPolicy
+import software.amazon.awssdk.core.retry.backoff.FullJitterBackoffStrategy
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.s3.S3Client
+
+import scala.collection.JavaConverters._
+
+case class AwsConfig(
+  accessKeyId: String,
+  secretAccessKey: String,
+  region: Region
+) {
+
+  def toClient: IO[S3Client] = IO.delay {
+    import RetryConstants._
+
+    val credentials = AwsBasicCredentials.create(accessKeyId, secretAccessKey)
+    val provider = StaticCredentialsProvider.create(credentials)
+
+    val overrideConfig = ClientOverrideConfiguration
+      .builder()
+      .retryPolicy(
+        RetryPolicy
+          .builder()
+          .numRetries(RetryCount)
+          .backoffStrategy(
+            FullJitterBackoffStrategy
+              .builder()
+              .baseDelay(Duration.ofMillis(RetryInitDelay.toMillis))
+              .maxBackoffTime(Duration.ofMillis(RetryMaxDelay.toMillis))
+              .build()
+          )
+          .build()
+      )
+      .apiCallAttemptTimeout(Duration.ofMillis(SingleRequestTimeout.toMillis))
+      .apiCallTimeout(Duration.ofMillis(TotalRequestTimeout.toMillis))
+      .build()
+
+    S3Client
+      .builder()
+      .region(region)
+      .credentialsProvider(provider)
+      .overrideConfiguration(overrideConfig)
+      .build()
+  }
+}
+
+object AwsConfig {
+  implicit val regionReader: ConfigReader[Region] =
+    ConfigReader.stringConfigReader.emap { str =>
+      Region
+        .regions()
+        .asScala
+        .find(_.id() == str)
+        .toRight(CannotConvert(str, "Region", "Not found in list of valid AWS regions"))
+    }
+
+  implicit val reader: ConfigReader[AwsConfig] = deriveReader
+}

--- a/agents/aws-to-gcp/src/main/scala/org/broadinstitute/transporter/config/GcpConfig.scala
+++ b/agents/aws-to-gcp/src/main/scala/org/broadinstitute/transporter/config/GcpConfig.scala
@@ -1,0 +1,53 @@
+package org.broadinstitute.transporter.config
+
+import java.nio.file.{Files, Path}
+
+import cats.effect.IO
+import com.google.api.gax.retrying.RetrySettings
+import com.google.auth.Credentials
+import com.google.auth.oauth2.{GoogleCredentials, ServiceAccountCredentials}
+import com.google.cloud.http.HttpTransportOptions
+import com.google.cloud.storage.{Storage, StorageOptions}
+import org.threeten.bp.Duration
+import pureconfig.ConfigReader
+import pureconfig.generic.semiauto.deriveReader
+
+case class GcpConfig(serviceAccountJson: Option[Path]) {
+
+  def toClient: IO[Storage] = IO.delay {
+    import RetryConstants._
+
+    val credentials: Credentials =
+      serviceAccountJson.fold(GoogleCredentials.getApplicationDefault) { jsonPath =>
+        ServiceAccountCredentials.fromStream(Files.newInputStream(jsonPath))
+      }
+
+    StorageOptions
+      .newBuilder()
+      .setCredentials(credentials)
+      .setTransportOptions(
+        HttpTransportOptions.newBuilder
+          .setConnectTimeout(120000)
+          .setReadTimeout(120000)
+          .build
+      )
+      .setRetrySettings(
+        RetrySettings.newBuilder
+          .setMaxAttempts(RetryCount)
+          .setInitialRetryDelay(Duration.ofMillis(RetryInitDelay.toMillis))
+          .setMaxRetryDelay(Duration.ofMillis(RetryMaxDelay.toMillis))
+          .setRetryDelayMultiplier(2.0)
+          .setInitialRpcTimeout(Duration.ofMillis(SingleRequestTimeout.toMillis))
+          .setMaxRpcTimeout(Duration.ofMillis(SingleRequestTimeout.toMillis))
+          .setRpcTimeoutMultiplier(1.0)
+          .setTotalTimeout(Duration.ofMillis(TotalRequestTimeout.toMillis))
+          .build
+      )
+      .build()
+      .getService
+  }
+}
+
+object GcpConfig {
+  implicit val reader: ConfigReader[GcpConfig] = deriveReader
+}

--- a/agents/aws-to-gcp/src/main/scala/org/broadinstitute/transporter/config/GcpConfig.scala
+++ b/agents/aws-to-gcp/src/main/scala/org/broadinstitute/transporter/config/GcpConfig.scala
@@ -12,8 +12,10 @@ import org.threeten.bp.Duration
 import pureconfig.ConfigReader
 import pureconfig.generic.semiauto.deriveReader
 
+/** Configuration determining how the AWS->GCP agent should connect to GCS. */
 case class GcpConfig(serviceAccountJson: Option[Path]) {
 
+  /** Build a GCS client using the auth configuration from this object. */
   def toClient: IO[Storage] = IO.delay {
     import RetryConstants._
 

--- a/agents/aws-to-gcp/src/main/scala/org/broadinstitute/transporter/config/RetryConstants.scala
+++ b/agents/aws-to-gcp/src/main/scala/org/broadinstitute/transporter/config/RetryConstants.scala
@@ -1,0 +1,35 @@
+package org.broadinstitute.transporter.config
+
+import scala.concurrent.duration._
+
+/**
+  * Retry configuration for underlying cloud clients used by the transfer runner.
+  *
+  * These values were originally picked by the GATK team and are also
+  * used in Picard and Clio. We've found they make NIO-like operations
+  * much less error-prone.
+  *
+  */
+object RetryConstants {
+
+  /** Max time to spend on a single attempt of an cloud operation. */
+  val SingleRequestTimeout: FiniteDuration = 180000.seconds
+
+  /**
+    * Max time to spend trying to complete a cloud operation,
+    * covering all retries.
+    */
+  val TotalRequestTimeout: FiniteDuration = 4000000.seconds
+
+  /** Max times to try completing a cloud operation. */
+  val RetryCount = 15
+
+  /**
+    * Time to wait between the first attempt of a cloud operation
+    * and the following retry.
+    */
+  val RetryInitDelay: FiniteDuration = 1.second
+
+  /** Max time to wait between attempts of a cloud operation. */
+  val RetryMaxDelay: FiniteDuration = 256.seconds
+}

--- a/agents/aws-to-gcp/src/main/scala/org/broadinstitute/transporter/config/RetryConstants.scala
+++ b/agents/aws-to-gcp/src/main/scala/org/broadinstitute/transporter/config/RetryConstants.scala
@@ -13,13 +13,13 @@ import scala.concurrent.duration._
 object RetryConstants {
 
   /** Max time to spend on a single attempt of an cloud operation. */
-  val SingleRequestTimeout: FiniteDuration = 180000.seconds
+  val SingleRequestTimeout: FiniteDuration = 3.minutes
 
   /**
     * Max time to spend trying to complete a cloud operation,
     * covering all retries.
     */
-  val TotalRequestTimeout: FiniteDuration = 4000000.seconds
+  val TotalRequestTimeout: FiniteDuration = 10.minutes
 
   /** Max times to try completing a cloud operation. */
   val RetryCount = 15

--- a/agents/aws-to-gcp/src/main/scala/org/broadinstitute/transporter/config/RunnerConfig.scala
+++ b/agents/aws-to-gcp/src/main/scala/org/broadinstitute/transporter/config/RunnerConfig.scala
@@ -1,0 +1,10 @@
+package org.broadinstitute.transporter.config
+
+import pureconfig.ConfigReader
+import pureconfig.generic.semiauto.deriveReader
+
+case class RunnerConfig(aws: AwsConfig, gcp: GcpConfig)
+
+object RunnerConfig {
+  implicit val reader: ConfigReader[RunnerConfig] = deriveReader
+}

--- a/agents/aws-to-gcp/src/main/scala/org/broadinstitute/transporter/config/RunnerConfig.scala
+++ b/agents/aws-to-gcp/src/main/scala/org/broadinstitute/transporter/config/RunnerConfig.scala
@@ -3,6 +3,7 @@ package org.broadinstitute.transporter.config
 import pureconfig.ConfigReader
 import pureconfig.generic.semiauto.deriveReader
 
+/** Top-level container for AWS->GCP configuration. */
 case class RunnerConfig(aws: AwsConfig, gcp: GcpConfig)
 
 object RunnerConfig {

--- a/agents/aws-to-gcp/src/main/scala/org/broadinstitute/transporter/transfer/AwsToGcpRequest.scala
+++ b/agents/aws-to-gcp/src/main/scala/org/broadinstitute/transporter/transfer/AwsToGcpRequest.scala
@@ -3,6 +3,18 @@ package org.broadinstitute.transporter.transfer
 import io.circe.Decoder
 import io.circe.derivation.deriveDecoder
 
+/**
+  * A request to copy a single file from AWS to GCP.
+  *
+  * @param s3Bucket name of the S3 bucket (without leading s3://) containing the file-to-copy
+  * @param s3Path path within `s3Bucket` (without leading /) pointing to the file-to-copy
+  * @param gcsBucket name of the GCS bucket (without leading gs://) to copy the file into
+  * @param gcsPath path within `gcsBucket` (without leading /) to copy the file into
+  * @param expectedSize expected Content-Length value of 's3://s3Bucket/s3Path'; the transfer
+  *                     will bail out early if a different size is found
+  * @param expectedMd5 expected content md5 of 's3://s3bucket/s3Path'; the transfer will fail
+  *                    to complete if a different md5 is computed
+  */
 case class AwsToGcpRequest(
   s3Bucket: String,
   s3Path: String,

--- a/agents/aws-to-gcp/src/main/scala/org/broadinstitute/transporter/transfer/AwsToGcpRequest.scala
+++ b/agents/aws-to-gcp/src/main/scala/org/broadinstitute/transporter/transfer/AwsToGcpRequest.scala
@@ -1,0 +1,17 @@
+package org.broadinstitute.transporter.transfer
+
+import io.circe.Decoder
+import io.circe.derivation.deriveDecoder
+
+case class AwsToGcpRequest(
+  s3Bucket: String,
+  s3Path: String,
+  gcsBucket: String,
+  gcsPath: String,
+  expectedSize: Option[Long],
+  expectedMd5: Option[String]
+)
+
+object AwsToGcpRequest {
+  implicit val decoder: Decoder[AwsToGcpRequest] = deriveDecoder
+}

--- a/agents/aws-to-gcp/src/main/scala/org/broadinstitute/transporter/transfer/AwsToGcpRunner.scala
+++ b/agents/aws-to-gcp/src/main/scala/org/broadinstitute/transporter/transfer/AwsToGcpRunner.scala
@@ -1,0 +1,148 @@
+package org.broadinstitute.transporter.transfer
+
+import cats.effect.{ContextShift, IO, Resource, Timer}
+import com.google.cloud.WriteChannel
+import com.google.cloud.storage.{BlobInfo, Storage}
+import fs2.concurrent.Queue
+import fs2.{Pipe, Stream}
+import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.{GetObjectRequest, HeadObjectRequest}
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+
+class AwsToGcpRunner(s3: S3Client, gcs: Storage)(
+  implicit cs: ContextShift[IO],
+  t: Timer[IO]
+) extends TransferRunner[AwsToGcpRequest] {
+  import AwsToGcpRunner._
+
+  private val logger = Slf4jLogger.getLogger[IO]
+
+  override def transfer(request: AwsToGcpRequest): IO[TransferSummary] = {
+    val s3Uri = s"s3://${request.s3Bucket}/${request.s3Path}"
+    val gcsUri = s"gs://${request.gcsBucket}/${request.gcsPath}"
+
+    for {
+      _ <- logger.info(s"Fetching metadata for $s3Uri")
+      s3Metadata <- IO.delay {
+        s3.headObject(
+          HeadObjectRequest
+            .builder()
+            .bucket(request.s3Bucket)
+            .key(request.s3Path)
+            .build()
+        )
+      }
+      // We can sanity-check expected size up-front, but not md5, since multipart uploads
+      // don't generate md5s for the final combined blob.
+      s3Size = s3Metadata.contentLength()
+      _ <- request.expectedSize.fold(
+        logger.warn(s"No expected size given for $s3Uri, skipping sanity-check")
+      ) { expectedSize =>
+        if (s3Size == expectedSize) {
+          logger.info(s"$s3Uri matches expected size; transferring to $gcsUri")
+        } else {
+          IO.raiseError(UnexpectedFileSize(s3Uri, expectedSize, s3Size))
+        }
+      }
+      _ <- {
+        val options = if (request.expectedMd5.isDefined) {
+          List(Storage.BlobWriteOption.md5Match())
+        } else {
+          Nil
+        }
+        val gcsBase = BlobInfo.newBuilder(request.gcsBucket, request.gcsPath)
+        val gcsTarget = request.expectedMd5
+          .fold(gcsBase)(gcsBase.setMd5FromHexString)
+          .setContentType(s3Metadata.contentType())
+          .setContentEncoding(s3Metadata.contentEncoding())
+          .setContentDisposition(s3Metadata.contentDisposition())
+          .build()
+        val s3Source =
+          GetObjectRequest.builder().bucket(request.s3Bucket).key(request.s3Path)
+
+        val open = IO.delay(gcs.writer(gcsTarget, options: _*))
+        val close = (w: WriteChannel) => IO.delay(w.close())
+        Resource.make(open)(close).use(runTransfer(s3Source, _, s3Size))
+      }
+    } yield {
+      // FIXME: Handle errors & report meaningful info
+      TransferSummary(TransferResult.Success, None)
+    }
+  }
+
+  private def runTransfer(
+    s3Builder: GetObjectRequest.Builder,
+    gcsWriter: WriteChannel,
+    fileSize: Long
+  ): IO[Unit] =
+    for {
+      buffer <- Queue.bounded[IO, Byte](BufferSize)
+      s3Pull = s3MultipartDownload(s3Builder, fileSize).through(buffer.enqueue)
+      gcsPush = buffer.dequeue.through(writeBytes(gcsWriter, fileSize))
+      // Order matters here: the argument to `concurrently` is considered the 'background'
+      // stream, and won't interrupt processing if it completes first.
+      _ <- gcsPush.concurrently(s3Pull).compile.drain
+    } yield ()
+
+  private def s3MultipartDownload(
+    reqBuilder: GetObjectRequest.Builder,
+    fileSize: Long
+  ): Stream[IO, Byte] =
+    Stream
+      .unfold(0L) { start =>
+        if (start == fileSize) {
+          None
+        } else {
+          val newStart = math.min(start + S3RangeSize, fileSize)
+          Some((start, newStart - 1) -> newStart)
+        }
+      }
+      .flatMap {
+        case (start, end) =>
+          val range = s"$start-$end"
+          val inStream = for {
+            _ <- logger.info(s"Pulling bytes $range from S3...")
+            respStream <- IO.delay(
+              s3.getObject(reqBuilder.range(s"bytes=$range").build())
+            )
+            _ <- logger.debug(s"Got response for range $range")
+          } yield {
+            respStream
+          }
+
+          // FIXME: This shouldn't use the global EC.
+          fs2.io.readInputStream[IO](inStream, 8192, ExecutionContext.global)
+      }
+
+  private def writeBytes(channel: WriteChannel, fileSize: Long): Pipe[IO, Byte, Unit] =
+    _.groupWithin(BytesPerMib, 5.seconds)
+      .evalScan(0L) {
+        case (numUploaded, byteChunk) =>
+          val nextNum = numUploaded + byteChunk.size
+          for {
+            _ <- logger.info(
+              s"Uploading bytes $numUploaded-${nextNum - 1} to GCS..."
+            )
+            // FIXME: This shouldn't use the global EC.
+            _ <- cs.evalOn(ExecutionContext.global)(
+              IO.delay(channel.write(byteChunk.toByteBuffer))
+            )
+          } yield nextNum
+      }
+      .takeWhile(_ < fileSize)
+      .map(_ => ())
+}
+
+object AwsToGcpRunner {
+  val BytesPerMib: Int = math.pow(2, 20).toInt
+  val S3RangeSize: Int = 5 * BytesPerMib
+  val BufferSize: Int = 512 * BytesPerMib
+
+  case class UnexpectedFileSize(uri: String, expected: Long, actual: Long)
+      extends IllegalStateException(
+        s"Object $uri has size $actual, but expected $expected"
+      )
+}

--- a/agents/echo/README.md
+++ b/agents/echo/README.md
@@ -10,7 +10,7 @@ Use this JSON schema to initialize Transporter queues for this agent:
   "type": "object",
   "properties": {
     "message": { "type":  "string" },
-    "fail": { "type":  "boolean" },
+    "fail": { "type":  "boolean" }
   },
   "required": ["message", "fail"],
   "additionalProperties": false

--- a/agents/echo/src/main/scala/org/broadinstitute/transporter/EchoAgent.scala
+++ b/agents/echo/src/main/scala/org/broadinstitute/transporter/EchoAgent.scala
@@ -1,7 +1,7 @@
 package org.broadinstitute.transporter
 
 import cats.effect.{IO, Resource}
-import org.broadinstitute.transporter.transfer.{EchoRunner, TransferRunner}
+import org.broadinstitute.transporter.transfer.{EchoInput, EchoRunner, TransferRunner}
 
 /**
   * Transporter agent which doesn't actually transfer data,
@@ -9,9 +9,10 @@ import org.broadinstitute.transporter.transfer.{EchoRunner, TransferRunner}
   *
   * Useful for manual plumbing tests.
   */
-object EchoAgent extends TransporterAgent[EchoConfig] {
+object EchoAgent extends TransporterAgent[EchoConfig, EchoInput] {
 
   override def runnerResource(
     config: EchoConfig
-  ): Resource[IO, TransferRunner[EchoConfig]] = Resource.pure(new EchoRunner(config))
+  ): Resource[IO, TransferRunner[EchoInput]] =
+    Resource.pure(new EchoRunner(config.transientFailureRate))
 }

--- a/agents/echo/src/main/scala/org/broadinstitute/transporter/transfer/EchoInput.scala
+++ b/agents/echo/src/main/scala/org/broadinstitute/transporter/transfer/EchoInput.scala
@@ -1,0 +1,10 @@
+package org.broadinstitute.transporter.transfer
+
+import io.circe.Decoder
+import io.circe.derivation.deriveDecoder
+
+case class EchoInput(message: String, fail: Boolean)
+
+object EchoInput {
+  implicit val decoder: Decoder[EchoInput] = deriveDecoder
+}

--- a/agents/template/src/main/scala/org/broadinstitute/transporter/transfer/TransferRunner.scala
+++ b/agents/template/src/main/scala/org/broadinstitute/transporter/transfer/TransferRunner.scala
@@ -1,7 +1,6 @@
 package org.broadinstitute.transporter.transfer
 
 import cats.effect.IO
-import io.circe.Json
 
 /**
   * Component capable of actually running data transfers.
@@ -9,10 +8,10 @@ import io.circe.Json
   * Agents are expected to "fill in" an instance of this interface
   * to handle specific storage source / destination pairs.
   */
-abstract class TransferRunner[RC](protected val config: RC) {
+abstract class TransferRunner[R] {
 
   /**
     * Run the transfer described by the given request.
     */
-  def transfer(request: Json): IO[TransferSummary]
+  def transfer(request: R): IO[TransferSummary]
 }

--- a/agents/template/src/test/scala/org/broadinstitute/transporter/kafka/TransferStreamSpec.scala
+++ b/agents/template/src/test/scala/org/broadinstitute/transporter/kafka/TransferStreamSpec.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.transporter.kafka
 
 import cats.effect.IO
 import cats.implicits._
-import io.circe.{Decoder, Encoder, Json}
+import io.circe.{Decoder, Encoder}
 import io.circe.derivation.{deriveDecoder, deriveEncoder}
 import io.circe.literal._
 import io.circe.parser.parse
@@ -170,12 +170,9 @@ object TransferStreamSpec {
 
   val UnhandledError = new RuntimeException("OH NO")
 
-  class EchoRunner(fail: Boolean) extends TransferRunner {
-    override def transfer(request: Json): IO[TransferSummary] =
-      request
-        .as[EchoRequest]
-        .flatMap(e => if (fail) Left(UnhandledError) else Right(e.result))
-        .liftTo[IO]
+  class EchoRunner(fail: Boolean) extends TransferRunner[EchoRequest] {
+    override def transfer(request: EchoRequest): IO[TransferSummary] =
+      if (fail) IO.raiseError(UnhandledError) else IO.pure(request.result)
   }
 
   case class EchoRequest(result: TransferSummary)

--- a/agents/template/src/test/scala/org/broadinstitute/transporter/kafka/TransferStreamSpec.scala
+++ b/agents/template/src/test/scala/org/broadinstitute/transporter/kafka/TransferStreamSpec.scala
@@ -170,7 +170,7 @@ object TransferStreamSpec {
 
   val UnhandledError = new RuntimeException("OH NO")
 
-  class EchoRunner(fail: Boolean) extends TransferRunner(fail) {
+  class EchoRunner(fail: Boolean) extends TransferRunner {
     override def transfer(request: Json): IO[TransferSummary] =
       request
         .as[EchoRequest]


### PR DESCRIPTION
This implementation streams all the bytes from S3 to GCS, so it doesn't need a local disk as temp space. This is good because we don't need to pre-allocate a bunch of big long-lived disks, but it's bad because it makes parallelizing the upload/download much more difficult.

Next step is to Dockerize it and try running in the cloud, to see performance.