### PR TITLE
DSPDC-280 Add retry wrapper to AWS/GCP requests.

### DIFF
--- a/agents/aws-to-gcp/src/main/resources/reference.conf
+++ b/agents/aws-to-gcp/src/main/resources/reference.conf
@@ -12,5 +12,17 @@ org.broadinstitute.transporter {
       # Fill this in to use non-default credentials.
       service-account-json: null
     }
+
+    # Timeouts & retry parameters copied from Clio's IO utils.
+
+    timeouts {
+      response-header-timeout: 2 minutes
+      request-timeout: 3 minutes
+    }
+
+    retries {
+      max-retries: 15
+      max-delay: 256 seconds
+    }
   }
 }

--- a/agents/aws-to-gcp/src/main/scala/org/broadinstitute/transporter/RetryConfig.scala
+++ b/agents/aws-to-gcp/src/main/scala/org/broadinstitute/transporter/RetryConfig.scala
@@ -1,0 +1,12 @@
+package org.broadinstitute.transporter
+
+import pureconfig.ConfigReader
+import pureconfig.generic.semiauto.deriveReader
+
+import scala.concurrent.duration.FiniteDuration
+
+case class RetryConfig(maxRetries: Int, maxDelay: FiniteDuration)
+
+object RetryConfig {
+  implicit val reader: ConfigReader[RetryConfig] = deriveReader
+}

--- a/agents/aws-to-gcp/src/main/scala/org/broadinstitute/transporter/RetryConfig.scala
+++ b/agents/aws-to-gcp/src/main/scala/org/broadinstitute/transporter/RetryConfig.scala
@@ -5,6 +5,12 @@ import pureconfig.generic.semiauto.deriveReader
 
 import scala.concurrent.duration.FiniteDuration
 
+/**
+  * Parameters for tweaking the approach used for retrying transient HTTP failures.
+  *
+  * @param maxRetries upper bound on number of times a single request can be retried
+  * @param maxDelay upper bound on time that can be spent between two retries of a single request
+  */
 case class RetryConfig(maxRetries: Int, maxDelay: FiniteDuration)
 
 object RetryConfig {

--- a/agents/aws-to-gcp/src/main/scala/org/broadinstitute/transporter/config/RunnerConfig.scala
+++ b/agents/aws-to-gcp/src/main/scala/org/broadinstitute/transporter/config/RunnerConfig.scala
@@ -1,10 +1,16 @@
 package org.broadinstitute.transporter.config
 
+import org.broadinstitute.transporter.RetryConfig
 import pureconfig.ConfigReader
 import pureconfig.generic.semiauto.deriveReader
 
 /** Top-level container for AWS->GCP configuration. */
-case class RunnerConfig(aws: AwsConfig, gcp: GcpConfig)
+case class RunnerConfig(
+  aws: AwsConfig,
+  gcp: GcpConfig,
+  timeouts: TimeoutConfig,
+  retries: RetryConfig
+)
 
 object RunnerConfig {
   implicit val reader: ConfigReader[RunnerConfig] = deriveReader

--- a/agents/aws-to-gcp/src/main/scala/org/broadinstitute/transporter/config/TimeoutConfig.scala
+++ b/agents/aws-to-gcp/src/main/scala/org/broadinstitute/transporter/config/TimeoutConfig.scala
@@ -1,0 +1,15 @@
+package org.broadinstitute.transporter.config
+
+import pureconfig.ConfigReader
+import pureconfig.generic.semiauto.deriveReader
+
+import scala.concurrent.duration.FiniteDuration
+
+case class TimeoutConfig(
+  responseHeaderTimeout: FiniteDuration,
+  requestTimeout: FiniteDuration
+)
+
+object TimeoutConfig {
+  implicit val reader: ConfigReader[TimeoutConfig] = deriveReader
+}

--- a/agents/aws-to-gcp/src/main/scala/org/broadinstitute/transporter/config/TimeoutConfig.scala
+++ b/agents/aws-to-gcp/src/main/scala/org/broadinstitute/transporter/config/TimeoutConfig.scala
@@ -5,6 +5,14 @@ import pureconfig.generic.semiauto.deriveReader
 
 import scala.concurrent.duration.FiniteDuration
 
+/**
+  * Timeouts to use for HTTP requests to AWS / GCP.
+  *
+  * @param responseHeaderTimeout amount of time to wait for headers to arrive for
+  *                              a response from AWS / GCP
+  * @param requestTimeout amount of time to wait to read the entire body of a response
+  *                       from AWS / GCP
+  */
 case class TimeoutConfig(
   responseHeaderTimeout: FiniteDuration,
   requestTimeout: FiniteDuration


### PR DESCRIPTION
This should help avoid more flaky failures.