### PR TITLE
DSPDC-383 DSPDC-402 Reproduce and fix deadlock on concurrent batch update

### DIFF
--- a/manager/db-migrations/src/main/resources/changesets/02-init-transfer-requests-table.xml
+++ b/manager/db-migrations/src/main/resources/changesets/02-init-transfer-requests-table.xml
@@ -19,6 +19,7 @@
         </createTable>
 
         <sql>
+            DROP TYPE IF EXISTS transfer_status;
             CREATE TYPE transfer_status AS ENUM ('submitted', 'failed', 'succeeded')
         </sql>
 

--- a/manager/src/test/scala/org/broadinstitute/transporter/PostgresSpec.scala
+++ b/manager/src/test/scala/org/broadinstitute/transporter/PostgresSpec.scala
@@ -3,22 +3,26 @@ package org.broadinstitute.transporter
 import java.sql.DriverManager
 
 import cats.effect.{ContextShift, IO, Resource}
-import com.dimafeng.testcontainers.{ForEachTestContainer, PostgreSQLContainer}
+import com.dimafeng.testcontainers.{ForAllTestContainer, PostgreSQLContainer}
 import doobie.util.transactor.Transactor
 import liquibase.{Contexts, Liquibase}
 import liquibase.database.jvm.JdbcConnection
 import liquibase.resource.ClassLoaderResourceAccessor
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.{BeforeAndAfterEach, FlatSpec, Matchers}
 
 import scala.concurrent.ExecutionContext
 
-trait PostgresSpec extends FlatSpec with Matchers with ForEachTestContainer {
+trait PostgresSpec
+    extends FlatSpec
+    with Matchers
+    with ForAllTestContainer
+    with BeforeAndAfterEach {
 
   protected implicit val cs: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
 
   override val container: PostgreSQLContainer = PostgreSQLContainer("postgres:9.6.10")
 
-  override def afterStart(): Unit = {
+  override def beforeEach(): Unit = {
     val acquireConn = for {
       _ <- IO(Class.forName(container.driverClassName))
       jdbc <- IO(
@@ -28,15 +32,17 @@ trait PostgresSpec extends FlatSpec with Matchers with ForEachTestContainer {
     } yield {
       new JdbcConnection(jdbc)
     }
-
     val releaseConn = (c: JdbcConnection) => IO.delay(c.close())
 
     Resource
       .make(acquireConn)(releaseConn)
-      .use { liquibaseConn =>
-        val accessor = new ClassLoaderResourceAccessor()
-        val liquibase = new Liquibase("changelog.xml", accessor, liquibaseConn)
-        IO.delay(liquibase.update(new Contexts()))
+      .use { conn =>
+        val liquibase =
+          new Liquibase("changelog.xml", new ClassLoaderResourceAccessor(), conn)
+        IO.delay {
+          liquibase.dropAll()
+          liquibase.update(new Contexts())
+        }
       }
       .unsafeRunSync()
   }

--- a/manager/src/test/scala/org/broadinstitute/transporter/info/InfoControllerSpec.scala
+++ b/manager/src/test/scala/org/broadinstitute/transporter/info/InfoControllerSpec.scala
@@ -1,5 +1,7 @@
 package org.broadinstitute.transporter.info
 
+import cats.effect.IO
+import doobie.util.transactor.Transactor
 import org.broadinstitute.transporter.PostgresSpec
 import org.scalamock.scalatest.MockFactory
 
@@ -21,8 +23,14 @@ class InfoControllerSpec extends PostgresSpec with MockFactory {
   }
 
   it should "report not-OK when the DB is unreachable" in {
-    val controller = new InfoController(version, transactor)
-    container.stop()
+    val badTransactor = Transactor.fromDriverManager[IO](
+      container.driverClassName,
+      container.jdbcUrl,
+      container.username,
+      "nope"
+    )
+
+    val controller = new InfoController(version, badTransactor)
 
     controller.status
       .unsafeRunSync() shouldBe ManagerStatus(

--- a/manager/src/test/scala/org/broadinstitute/transporter/transfer/TransferListenerSpec.scala
+++ b/manager/src/test/scala/org/broadinstitute/transporter/transfer/TransferListenerSpec.scala
@@ -25,7 +25,7 @@ class TransferListenerSpec extends PostgresSpec with MockFactory with EitherValu
   private val results = mock[KafkaConsumer[(TransferResult, Json)]]
 
   private val request1Id = UUID.randomUUID()
-  private val request1Transfers = List.tabulate(10) { i =>
+  private val request1Transfers = List.tabulate(50) { i =>
     UUID.randomUUID() -> json"""{ "i": $i }"""
   }
 

--- a/manager/src/test/scala/org/broadinstitute/transporter/transfer/config/TransferSchemaSpec.scala
+++ b/manager/src/test/scala/org/broadinstitute/transporter/transfer/config/TransferSchemaSpec.scala
@@ -5,7 +5,7 @@ import io.circe.syntax._
 import org.scalatest.{EitherValues, FlatSpec, Matchers}
 
 class TransferSchemaSpec extends FlatSpec with Matchers with EitherValues {
-  behavior of "QueueSchema"
+  behavior of "TransferSchema"
 
   private val draft4Schema = json"""{
     "$$schema": ${TransferSchema.schemaUrl(4)},


### PR DESCRIPTION
Batch updates lock rows one-at-a-time. If two concurrent batch updates touch overlapping sets of rows, they need to update the rows in the same order. Otherwise you'll get a deadlock when:
1. Update 1 locks row A
2. Update 2 locks row B
3. Update 1 tries to lock row B, and waits
4. Update 2 tries to lock row A, and waits