### PR TITLE
DSPDC-361 Add new manager endpoint to list summaries all transfers

### DIFF
--- a/manager/db-migrations/src/main/resources/changelog.xml
+++ b/manager/db-migrations/src/main/resources/changelog.xml
@@ -14,4 +14,5 @@
     <include file="changesets/10-drop-queues.xml" relativeToChangelogFile="true" />
     <include file="changesets/11-add-steps-run.xml" relativeToChangelogFile="true" />
     <include file="changesets/12-enable-tablefunc.xml" relativeToChangelogFile="true" />
+    <include file="changesets/13-add-request-received-time.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/manager/db-migrations/src/main/resources/changelog.xml
+++ b/manager/db-migrations/src/main/resources/changelog.xml
@@ -13,4 +13,5 @@
     <include file="changesets/09-add-queue-partition-tracking.xml" relativeToChangelogFile="true" />
     <include file="changesets/10-drop-queues.xml" relativeToChangelogFile="true" />
     <include file="changesets/11-add-steps-run.xml" relativeToChangelogFile="true" />
+    <include file="changesets/12-enable-tablefunc.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/manager/db-migrations/src/main/resources/changesets/12-enable-tablefunc.xml
+++ b/manager/db-migrations/src/main/resources/changesets/12-enable-tablefunc.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="12" author="danmoran">
+
+        <sql>CREATE EXTENSION IF NOT EXISTS tablefunc</sql>
+
+        <rollback>
+            <sql>DROP EXTENSION tablefunc</sql>
+        </rollback>
+
+    </changeSet>
+
+</databaseChangeLog>

--- a/manager/db-migrations/src/main/resources/changesets/13-add-request-received-time.xml
+++ b/manager/db-migrations/src/main/resources/changesets/13-add-request-received-time.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="13" author="danmoran">
+
+        <addColumn tableName="transfer_requests">
+            <column name="received_at" type="timestamp" />
+        </addColumn>
+
+        <sql>
+            UPDATE transfer_requests SET received_at = (now() at time zone 'utc')::timestamp
+        </sql>
+
+        <addNotNullConstraint tableName="transfer_requests" columnName="received_at" />
+
+        <createIndex tableName="transfer_requests" indexName="transfer_requests_received_at">
+            <column name="received_at" />
+        </createIndex>
+
+        <rollback>
+            <dropColumn tableName="transfer_requests" columnName="received_at" />
+        </rollback>
+
+    </changeSet>
+
+</databaseChangeLog>

--- a/manager/src/main/scala/org/broadinstitute/transporter/db/DoobieInstances.scala
+++ b/manager/src/main/scala/org/broadinstitute/transporter/db/DoobieInstances.scala
@@ -7,16 +7,32 @@ import cats.implicits._
 import doobie.Get
 import doobie.postgres.{Instances => PostgresInstances}
 import doobie.postgres.circe.Instances.JsonInstances
-import io.circe.Json
-import org.broadinstitute.transporter.transfer.TransferStatus
+import io.circe.{Decoder, Json, KeyDecoder}
 
+import scala.reflect.runtime.universe.TypeTag
+
+/**
+  * Container for orphan typeclass instances needed by Transporter to
+  * interact with Postgres via doobie.
+  */
 object DoobieInstances extends PostgresInstances with JsonInstances {
 
+  /**
+    * Typeclass which can read `OffsetDateTime`s from Postgres.
+    *
+    * First reads values as a SQL timestamp, then converts the underlying
+    * instant into a datetime in UTC.
+    */
   implicit val odtGet: Get[OffsetDateTime] = Get[Timestamp].tmap { ts =>
     OffsetDateTime.ofInstant(ts.toInstant, ZoneId.of("UTC"))
   }
 
-  implicit val mapGetter: Get[Map[TransferStatus, Long]] =
-    Get[Json].temap(_.hcursor.as[Map[TransferStatus, Long]].leftMap(_.getMessage()))
+  /**
+    * Derivation helper which can produce a typeclass for reading any concrete
+    * `Map[K, V]` type from Postgres, as long as we know how to decode JSON into
+    * an instance of that Map type.
+    */
+  implicit def mapGet[K: KeyDecoder: TypeTag, V: Decoder: TypeTag]: Get[Map[K, V]] =
+    Get[Json].temap(_.hcursor.as[Map[K, V]].leftMap(_.getMessage()))
 
 }

--- a/manager/src/main/scala/org/broadinstitute/transporter/db/DoobieInstances.scala
+++ b/manager/src/main/scala/org/broadinstitute/transporter/db/DoobieInstances.scala
@@ -3,13 +3,20 @@ package org.broadinstitute.transporter.db
 import java.sql.Timestamp
 import java.time.{OffsetDateTime, ZoneId}
 
+import cats.implicits._
+import doobie.Get
 import doobie.postgres.{Instances => PostgresInstances}
 import doobie.postgres.circe.Instances.JsonInstances
-import doobie.util.Get
+import io.circe.Json
+import org.broadinstitute.transporter.transfer.TransferStatus
 
 object DoobieInstances extends PostgresInstances with JsonInstances {
 
-  implicit val odtGet: Get[OffsetDateTime] = Get[Timestamp].map { ts =>
+  implicit val odtGet: Get[OffsetDateTime] = Get[Timestamp].tmap { ts =>
     OffsetDateTime.ofInstant(ts.toInstant, ZoneId.of("UTC"))
   }
+
+  implicit val mapGetter: Get[Map[TransferStatus, Long]] =
+    Get[Json].temap(_.hcursor.as[Map[TransferStatus, Long]].leftMap(_.getMessage()))
+
 }

--- a/manager/src/main/scala/org/broadinstitute/transporter/transfer/TransferController.scala
+++ b/manager/src/main/scala/org/broadinstitute/transporter/transfer/TransferController.scala
@@ -40,6 +40,10 @@ class TransferController(
   private val logger = Slf4jLogger.getLogger[IO]
   private implicit val logHandler: LogHandler = DbLogHandler(logger)
 
+  /**
+    * Fetch summaries of all the batch requests stored by Transporter
+    * which fall within a specified page range.
+    */
   def listRequests(
     offset: Long,
     limit: Long,
@@ -48,6 +52,13 @@ class TransferController(
     lookupSummaries(Left((offset, limit)), newestFirst)
       .transact(dbClient)
 
+  /**
+    * Fetch summaries of either:
+    *   1. All batch requests stored by Transporter which fall in a page range, or
+    *   2. A specific batch requests, identified by ID
+    *
+    * Batch requests are ordered by their IDs for now.
+    */
   private def lookupSummaries(
     paginationOrId: Either[(Long, Long), UUID],
     newestFirst: Boolean = true

--- a/manager/src/main/scala/org/broadinstitute/transporter/transfer/api/RequestSummary.scala
+++ b/manager/src/main/scala/org/broadinstitute/transporter/transfer/api/RequestSummary.scala
@@ -12,6 +12,7 @@ import org.broadinstitute.transporter.transfer.TransferStatus
   * to the Transporter manager.
   *
   * @param id unique ID of the request
+  * @param receivedAt timestamp when the request batch was stored by Transporter
   * @param statusCounts counts of the transfers in each potential "transfer status"
   *                     registered under the request
   * @param submittedAt timestamp when the first transfer of the request was submitted
@@ -21,6 +22,7 @@ import org.broadinstitute.transporter.transfer.TransferStatus
   */
 case class RequestSummary(
   id: UUID,
+  receivedAt: OffsetDateTime,
   statusCounts: Map[TransferStatus, Long],
   submittedAt: Option[OffsetDateTime],
   updatedAt: Option[OffsetDateTime]

--- a/manager/src/main/scala/org/broadinstitute/transporter/transfer/api/RequestSummary.scala
+++ b/manager/src/main/scala/org/broadinstitute/transporter/transfer/api/RequestSummary.scala
@@ -12,8 +12,6 @@ import org.broadinstitute.transporter.transfer.TransferStatus
   * to the Transporter manager.
   *
   * @param id unique ID of the request
-  * @param overallStatus top-level status for the request, derived based on
-  *                      the counts of individual statuses in `statusCounts`
   * @param statusCounts counts of the transfers in each potential "transfer status"
   *                     registered under the request
   * @param submittedAt timestamp when the first transfer of the request was submitted
@@ -21,15 +19,14 @@ import org.broadinstitute.transporter.transfer.TransferStatus
   * @param updatedAt timestamp of the last message received from Kafka about a transfer
   *                  under this request
   */
-case class RequestStatus(
+case class RequestSummary(
   id: UUID,
-  overallStatus: TransferStatus,
   statusCounts: Map[TransferStatus, Long],
   submittedAt: Option[OffsetDateTime],
   updatedAt: Option[OffsetDateTime]
 )
 
-object RequestStatus {
-  implicit val decoder: Decoder[RequestStatus] = deriveDecoder
-  implicit val encoder: Encoder[RequestStatus] = deriveEncoder
+object RequestSummary {
+  implicit val decoder: Decoder[RequestSummary] = deriveDecoder
+  implicit val encoder: Encoder[RequestSummary] = deriveEncoder
 }

--- a/manager/src/main/scala/org/broadinstitute/transporter/web/Page.scala
+++ b/manager/src/main/scala/org/broadinstitute/transporter/web/Page.scala
@@ -1,0 +1,11 @@
+package org.broadinstitute.transporter.web
+
+import io.circe.{Decoder, Encoder}
+import io.circe.derivation.{deriveDecoder, deriveEncoder}
+
+case class Page[I](items: List[I], total: Long)
+
+object Page {
+  implicit def decoder[I: Decoder]: Decoder[Page[I]] = deriveDecoder
+  implicit def encoder[I: Encoder]: Encoder[Page[I]] = deriveEncoder
+}

--- a/manager/src/main/scala/org/broadinstitute/transporter/web/Page.scala
+++ b/manager/src/main/scala/org/broadinstitute/transporter/web/Page.scala
@@ -3,7 +3,13 @@ package org.broadinstitute.transporter.web
 import io.circe.{Decoder, Encoder}
 import io.circe.derivation.{deriveDecoder, deriveEncoder}
 
-case class Page[I](items: List[I], total: Long)
+/**
+  * Generic API envelope for a page of query results.
+  *
+  * @param items query results to return to the client
+  * @param total the number of elements included in `items`
+  */
+case class Page[I](items: List[I], total: Int)
 
 object Page {
   implicit def decoder[I: Decoder]: Decoder[Page[I]] = deriveDecoder

--- a/manager/src/main/scala/org/broadinstitute/transporter/web/Page.scala
+++ b/manager/src/main/scala/org/broadinstitute/transporter/web/Page.scala
@@ -7,9 +7,9 @@ import io.circe.derivation.{deriveDecoder, deriveEncoder}
   * Generic API envelope for a page of query results.
   *
   * @param items query results to return to the client
-  * @param total the number of elements included in `items`
+  * @param total the total number of items stored across all pages
   */
-case class Page[I](items: List[I], total: Int)
+case class Page[I](items: List[I], total: Long)
 
 object Page {
   implicit def decoder[I: Decoder]: Decoder[Page[I]] = deriveDecoder

--- a/manager/src/main/scala/org/broadinstitute/transporter/web/SortOrder.scala
+++ b/manager/src/main/scala/org/broadinstitute/transporter/web/SortOrder.scala
@@ -1,0 +1,15 @@
+package org.broadinstitute.transporter.web
+
+import enumeratum.{Enum, EnumEntry}
+import enumeratum.EnumEntry.Lowercase
+
+import scala.collection.immutable.IndexedSeq
+
+sealed trait SortOrder extends EnumEntry with Lowercase
+
+object SortOrder extends Enum[SortOrder] {
+  override val values: IndexedSeq[SortOrder] = findValues
+
+  case object Asc extends SortOrder
+  case object Desc extends SortOrder
+}

--- a/manager/src/main/scala/org/broadinstitute/transporter/web/SortOrder.scala
+++ b/manager/src/main/scala/org/broadinstitute/transporter/web/SortOrder.scala
@@ -5,6 +5,12 @@ import enumeratum.EnumEntry.Lowercase
 
 import scala.collection.immutable.IndexedSeq
 
+/**
+  * Enum modeling valid sort orders for lookup requests.
+  *
+  * Scoped at the `web` layer because it's mainly useful for
+  * generating detailed OpenAPI documentation.
+  */
 sealed trait SortOrder extends EnumEntry with Lowercase
 
 object SortOrder extends Enum[SortOrder] {

--- a/manager/src/main/scala/org/broadinstitute/transporter/web/WebApi.scala
+++ b/manager/src/main/scala/org/broadinstitute/transporter/web/WebApi.scala
@@ -124,10 +124,15 @@ class WebApi(
     .description("List all transfer batches known to Transporter")
     .serverLogic {
       case (offset, limit, sort) =>
+        val getPage = transferController.listRequests(
+          offset,
+          limit,
+          newestFirst = sort == SortOrder.Desc
+        )
+        val getTotal = transferController.countRequests
+
         buildResponse(
-          transferController
-            .listRequests(offset, limit, newestFirst = sort == SortOrder.Desc)
-            .map(requests => Page(requests, requests.length)),
+          (getPage, getTotal).parMapN { case (items, total) => Page(items, total) },
           "Failed to list transfer batches"
         )
     }

--- a/manager/src/test/resources/logback-test.xml
+++ b/manager/src/test/resources/logback-test.xml
@@ -18,7 +18,7 @@
         <appender-ref ref="DOCKER-STDOUT" />
     </logger>
 
-    <!-- Kafka and Zookeeper are *very* noisy. -->
+    <!-- Suppress particularly noisy systems. -->
     <logger name="kafka" level="WARN" additivity="false">
         <appender-ref ref="STDOUT" />
     </logger>
@@ -26,6 +26,9 @@
         <appender-ref ref="STDOUT" />
     </logger>
     <logger name="org.apache.zookeeper" level="WARN" additivity="false">
+        <appender-ref ref="STDOUT" />
+    </logger>
+    <logger name="liquibase" level="WARN" additivity="false">
         <appender-ref ref="STDOUT" />
     </logger>
 

--- a/manager/src/test/scala/org/broadinstitute/transporter/transfer/TransferControllerSpec.scala
+++ b/manager/src/test/scala/org/broadinstitute/transporter/transfer/TransferControllerSpec.scala
@@ -78,7 +78,7 @@ class TransferControllerSpec extends PostgresSpec with MockFactory with EitherVa
           countRequests.query[Long].unique,
           countTransfers.query[Long].unique
         ).tupled.transact(tx)
-        ack <- controller.recordTransfer(request)
+        ack <- controller.recordRequest(request)
         (postRequests, postTransfers) <- (
           (countRequests ++ fr"where id = ${ack.id}")
             .query[Long]
@@ -104,7 +104,7 @@ class TransferControllerSpec extends PostgresSpec with MockFactory with EitherVa
           countRequests.query[Long].unique,
           countTransfers.query[Long].unique
         ).tupled.transact(tx)
-        ackOrErr <- controller.recordTransfer(request).attempt
+        ackOrErr <- controller.recordRequest(request).attempt
         (postRequests, postTransfers) <- (
           countRequests.query[Long].unique,
           countTransfers.query[Long].unique
@@ -118,220 +118,81 @@ class TransferControllerSpec extends PostgresSpec with MockFactory with EitherVa
       }
   }
 
-  it should "get summaries for registered transfers" in withRequest { (_, controller) =>
-    for {
-      summary1 <- controller.lookupRequestStatus(request1Id)
-      summary2 <- controller.lookupRequestStatus(request2Id)
-    } yield {
-      summary1 shouldBe RequestStatus(
-        request1Id,
-        TransferStatus.Pending,
-        TransferStatus.values.map(_ -> 0L).toMap ++ Map(
-          TransferStatus.Pending -> request1Transfers.length.toLong
-        ),
-        None,
-        None
-      )
-      summary2 shouldBe RequestStatus(
-        request2Id,
-        TransferStatus.Pending,
-        TransferStatus.values.map(_ -> 0L).toMap ++ Map(
-          TransferStatus.Pending -> request2Transfers.length.toLong
-        ),
-        None,
-        None
-      )
-    }
-  }
+  it should "get summaries for registered transfers" in withRequest { (tx, controller) =>
+    val now = Instant.now
+    val fakeSubmitted = request1Transfers.take(3).map(_._1)
+    val fakeInProgress = request1Transfers(6)._1
+    val fakeSucceeded = request1Transfers.takeRight(2).map(_._1)
+    val fakeFailed = request1Transfers.slice(3, 6).map(_._1)
 
-  it should "prioritize 'inprogress' status over all in request summaries" in withRequest {
-    (tx, controller) =>
-      val now = Instant.now
-      val fakeSubmitted = request1Transfers.take(3).map(_._1)
-      val fakeInProgress = request1Transfers(6)._1
-      val fakeSucceeded = request1Transfers.takeRight(2).map(_._1)
-      val fakeFailed = request1Transfers.slice(3, 6).map(_._1)
-
-      val transaction = for {
-        _ <- fakeSubmitted.traverse_ { id =>
-          sql"""update transfers set
+    val transaction = for {
+      _ <- fakeSubmitted.traverse_ { id =>
+        sql"""update transfers set
                 status = ${TransferStatus.Submitted: TransferStatus},
                 submitted_at = ${Timestamp.from(now)}
                 where id = $id""".update.run
-        }
-        _ <- sql"""update transfers set
+      }
+      _ <- sql"""update transfers set
                    status = ${TransferStatus.InProgress: TransferStatus},
                    submitted_at = ${Timestamp.from(now)},
                    updated_at = ${Timestamp.from(now.plusMillis(10000))}
                    where id = $fakeInProgress""".update.run
-        _ <- fakeSucceeded.traverse_ { id =>
-          sql"""update transfers set
+      _ <- fakeSucceeded.traverse_ { id =>
+        sql"""update transfers set
                 status = ${TransferStatus.Succeeded: TransferStatus},
                 submitted_at = ${Timestamp.from(now.minusMillis(30000))},
                 updated_at = ${Timestamp.from(now)}
                 where id = $id""".update.run
-        }
-        _ <- fakeFailed.traverse_ { id =>
-          sql"""update transfers set
+      }
+      _ <- fakeFailed.traverse_ { id =>
+        sql"""update transfers set
                 status = ${TransferStatus.Failed: TransferStatus},
                 submitted_at = ${Timestamp.from(now.plusMillis(30000))},
                 updated_at = ${Timestamp.from(now.minusMillis(30000))}
                 where id = $id""".update.run
-        }
-      } yield ()
-
-      for {
-        _ <- transaction.transact(tx)
-        summary <- controller.lookupRequestStatus(request1Id)
-      } yield {
-        summary shouldBe RequestStatus(
-          request1Id,
-          TransferStatus.InProgress,
-          Map(
-            TransferStatus.Pending -> 1,
-            TransferStatus.Submitted -> 3,
-            TransferStatus.Failed -> 3,
-            TransferStatus.Succeeded -> 2,
-            TransferStatus.InProgress -> 1
-          ),
-          Some(OffsetDateTime.ofInstant(now.minusMillis(30000), ZoneId.of("UTC"))),
-          Some(OffsetDateTime.ofInstant(now.plusMillis(10000), ZoneId.of("UTC")))
-        )
       }
+    } yield ()
+
+    for {
+      _ <- transaction.transact(tx)
+      summary <- controller.lookupRequestStatus(request1Id)
+    } yield {
+      summary shouldBe RequestSummary(
+        request1Id,
+        Map(
+          TransferStatus.Pending -> 1,
+          TransferStatus.Submitted -> 3,
+          TransferStatus.Failed -> 3,
+          TransferStatus.Succeeded -> 2,
+          TransferStatus.InProgress -> 1
+        ),
+        Some(OffsetDateTime.ofInstant(now.minusMillis(30000), ZoneId.of("UTC"))),
+        Some(OffsetDateTime.ofInstant(now.plusMillis(10000), ZoneId.of("UTC")))
+      )
+    }
   }
 
-  it should "prioritize 'submitted' status over 'pending' in request summaries" in withRequest {
-    (tx, controller) =>
-      val now = Instant.now
-      val fakeSubmitted = request1Transfers.take(3).map(_._1)
-      val fakeSucceeded = request1Transfers.takeRight(2).map(_._1)
-      val fakeFailed = request1Transfers.slice(3, 6).map(_._1)
-
-      val transaction = for {
-        _ <- fakeSubmitted.traverse_ { id =>
-          sql"""update transfers set
-                status = ${TransferStatus.Submitted: TransferStatus},
-                submitted_at = ${Timestamp.from(now)}
-                where id = $id""".update.run
-        }
-        _ <- fakeSucceeded.traverse_ { id =>
-          sql"""update transfers set
-                status = ${TransferStatus.Succeeded: TransferStatus},
-                submitted_at = ${Timestamp.from(now.minusMillis(30000))},
-                updated_at = ${Timestamp.from(now)}
-                where id = $id""".update.run
-        }
-        _ <- fakeFailed.traverse_ { id =>
-          sql"""update transfers set
-                status = ${TransferStatus.Failed: TransferStatus},
-                submitted_at = ${Timestamp.from(now.plusMillis(30000))},
-                updated_at = ${Timestamp.from(now.minusMillis(30000))}
-                where id = $id""".update.run
-        }
-      } yield ()
-
+  it should "include zero counts for unrepresented statuses in request summaries" in withRequest {
+    (_, controller) =>
       for {
-        _ <- transaction.transact(tx)
-        summary <- controller.lookupRequestStatus(request1Id)
+        summary1 <- controller.lookupRequestStatus(request1Id)
+        summary2 <- controller.lookupRequestStatus(request2Id)
       } yield {
-        summary shouldBe RequestStatus(
+        summary1 shouldBe RequestSummary(
           request1Id,
-          TransferStatus.Submitted,
-          Map(
-            TransferStatus.Pending -> 2,
-            TransferStatus.Submitted -> 3,
-            TransferStatus.Failed -> 3,
-            TransferStatus.Succeeded -> 2,
-            TransferStatus.InProgress -> 0
+          TransferStatus.values.map(_ -> 0L).toMap ++ Map(
+            TransferStatus.Pending -> request1Transfers.length.toLong
           ),
-          Some(OffsetDateTime.ofInstant(now.minusMillis(30000), ZoneId.of("UTC"))),
-          Some(OffsetDateTime.ofInstant(now, ZoneId.of("UTC")))
+          None,
+          None
         )
-      }
-  }
-
-  it should "prioritize 'pending' status over terminal statuses in request summaries" in withRequest {
-    (tx, controller) =>
-      val now = Instant.now
-      val fakeSucceeded = request1Transfers.takeRight(4).map(_._1)
-      val fakeFailed = request1Transfers.take(4).map(_._1)
-
-      val transaction = for {
-        _ <- fakeSucceeded.traverse_ { id =>
-          sql"""update transfers set
-                status = ${TransferStatus.Succeeded: TransferStatus},
-                submitted_at = ${Timestamp.from(now.minusMillis(30000))},
-                updated_at = ${Timestamp.from(now)}
-                where id = $id""".update.run
-        }
-        _ <- fakeFailed.traverse_ { id =>
-          sql"""update transfers set
-                status = ${TransferStatus.Failed: TransferStatus},
-                submitted_at = ${Timestamp.from(now.plusMillis(30000))},
-                updated_at = ${Timestamp.from(now.minusMillis(30000))}
-                where id = $id""".update.run
-        }
-      } yield ()
-
-      for {
-        _ <- transaction.transact(tx)
-        summary <- controller.lookupRequestStatus(request1Id)
-      } yield {
-        summary shouldBe RequestStatus(
-          request1Id,
-          TransferStatus.Pending,
-          Map(
-            TransferStatus.Pending -> 2,
-            TransferStatus.Submitted -> 0,
-            TransferStatus.Succeeded -> 4,
-            TransferStatus.Failed -> 4,
-            TransferStatus.InProgress -> 0
+        summary2 shouldBe RequestSummary(
+          request2Id,
+          TransferStatus.values.map(_ -> 0L).toMap ++ Map(
+            TransferStatus.Pending -> request2Transfers.length.toLong
           ),
-          Some(OffsetDateTime.ofInstant(now.minusMillis(30000), ZoneId.of("UTC"))),
-          Some(OffsetDateTime.ofInstant(now, ZoneId.of("UTC")))
-        )
-      }
-  }
-
-  it should "prioritize failures over successes in request summaries" in withRequest {
-    (tx, controller) =>
-      val now = Instant.now
-      val fakeSucceeded = request1Transfers.take(8).map(_._1)
-      val fakeFailed = request1Transfers.takeRight(2).map(_._1)
-
-      val transaction = for {
-        _ <- fakeSucceeded.traverse_ { id =>
-          sql"""update transfers set
-                status = ${TransferStatus.Succeeded: TransferStatus},
-                submitted_at = ${Timestamp.from(now.minusMillis(30000))},
-                updated_at = ${Timestamp.from(now)}
-                where id = $id""".update.run
-        }
-        _ <- fakeFailed.traverse_ { id =>
-          sql"""update transfers set
-                status = ${TransferStatus.Failed: TransferStatus},
-                submitted_at = ${Timestamp.from(now.plusMillis(30000))},
-                updated_at = ${Timestamp.from(now.minusMillis(30000))}
-                where id = $id""".update.run
-        }
-      } yield ()
-
-      for {
-        _ <- transaction.transact(tx)
-        summary <- controller.lookupRequestStatus(request1Id)
-      } yield {
-        summary shouldBe RequestStatus(
-          request1Id,
-          TransferStatus.Failed,
-          Map(
-            TransferStatus.Pending -> 0,
-            TransferStatus.Submitted -> 0,
-            TransferStatus.Succeeded -> 8,
-            TransferStatus.Failed -> 2,
-            TransferStatus.InProgress -> 0
-          ),
-          Some(OffsetDateTime.ofInstant(now.minusMillis(30000), ZoneId.of("UTC"))),
-          Some(OffsetDateTime.ofInstant(now, ZoneId.of("UTC")))
+          None,
+          None
         )
       }
   }

--- a/manager/src/test/scala/org/broadinstitute/transporter/transfer/TransferSubmitterSpec.scala
+++ b/manager/src/test/scala/org/broadinstitute/transporter/transfer/TransferSubmitterSpec.scala
@@ -1,6 +1,7 @@
 package org.broadinstitute.transporter.transfer
 
-import java.time.OffsetDateTime
+import java.sql.Timestamp
+import java.time.{Instant, OffsetDateTime}
 import java.util.UUID
 
 import cats.effect.{IO, Timer}
@@ -44,8 +45,10 @@ class TransferSubmitterSpec extends PostgresSpec with MockFactory with EitherVal
       new TransferSubmitter(theTopic, parallelism.toLong, interval, tx, kafka)
 
     val setup = for {
-      _ <- List(request1Id, request2Id).traverse_ { id =>
-        sql"insert into transfer_requests (id) values ($id)".update.run.void
+      _ <- List(request1Id, request2Id).zipWithIndex.traverse_ {
+        case (id, i) =>
+          val ts = Timestamp.from(Instant.ofEpochMilli(i.toLong))
+          sql"insert into transfer_requests (id, received_at) values ($id, $ts)".update.run.void
       }
       _ <- request1Transfers.traverse_ {
         case (id, body) =>


### PR DESCRIPTION
I refactored the existing summary lookup to push more logic into the DB, and to let us use the same code for both:
1. Looking up a range of summaries
2. Looking up a specific summary

As part of the refactor, I asked Ops how they'd like individual transfer-level statuses to be rolled up into a request-level status. They said a map of counts would be enough, and that a top-level flag could be confusing in a rush. I removed the "overallStatus" field from the request summary model accordingly.