### PR TITLE
Ra dspdc 360 single transfer

### DIFF
--- a/manager/README.md
+++ b/manager/README.md
@@ -48,6 +48,7 @@ Paths below prefixed with `/api/transporter/v1/transfers/{request-id}`.
 
 | Verb | Path | Description |
 | ---- | ---- | ----------- |
+| PUT | `/reconsider/{transfer-id}` | Reset the state of a specific failed transfer in a request to 'Pending'. |
 | GET | `/detail/{transfer-id}` | Get all information stored by the Manager about a specific transfer under a bulk request. |
 
 ## Running Locally

--- a/manager/README.md
+++ b/manager/README.md
@@ -48,7 +48,7 @@ Paths below prefixed with `/api/transporter/v1/transfers/{request-id}`.
 
 | Verb | Path | Description |
 | ---- | ---- | ----------- |
-| PUT | `/reconsider/{transfer-id}` | Reset the state of a specific failed transfer in a request to 'Pending'. |
+| PUT | `/detail/{transfer-id}/reconsider` | Reset the state of a specific failed transfer in a request to 'Pending'. |
 | GET | `/detail/{transfer-id}` | Get all information stored by the Manager about a specific transfer under a bulk request. |
 
 ## Running Locally

--- a/manager/src/main/scala/org/broadinstitute/transporter/web/WebApi.scala
+++ b/manager/src/main/scala/org/broadinstitute/transporter/web/WebApi.scala
@@ -220,7 +220,7 @@ class WebApi(
       }
 
   private val reconsiderSingleTransferRoute: Route[(UUID, UUID), ApiError, RequestAck] =
-    transferBase
+    requestBase
       .in("reconsider" / path[UUID]("transfer-id"))
       .put
       .out(jsonBody[RequestAck])

--- a/manager/src/main/scala/org/broadinstitute/transporter/web/WebApi.scala
+++ b/manager/src/main/scala/org/broadinstitute/transporter/web/WebApi.scala
@@ -191,7 +191,9 @@ class WebApi(
       .in("reconsider" / path[UUID]("transfer-id"))
       .put
       .out(jsonBody[RequestAck])
-      .description("Reset the state of a single failed transfer in a request to 'pending'")
+      .description(
+        "Reset the state of a single failed transfer in a request to 'pending'"
+      )
       .serverLogic {
         case (requestId, transferId) =>
           buildResponse(

--- a/manager/src/main/scala/org/broadinstitute/transporter/web/WebApi.scala
+++ b/manager/src/main/scala/org/broadinstitute/transporter/web/WebApi.scala
@@ -186,6 +186,20 @@ class WebApi(
         )
       }
 
+  private val reconsiderSingleTransferRoute: Route[(UUID, UUID), ApiError, RequestAck] =
+    transferBase
+      .in("reconsider" / path[UUID]("transfer-id"))
+      .put
+      .out(jsonBody[RequestAck])
+      .description("Reset the state of a single failed transfer in a request to 'pending'")
+      .serverLogic {
+        case (requestId, transferId) =>
+          buildResponse(
+            transferController.reconsiderSingleTransfer(requestId, transferId),
+            s"Failed to reconsider transfer for $transferId in request $requestId"
+          )
+      }
+
   private val detailsRoute: Route[(UUID, UUID), ApiError, TransferDetails] =
     transferBase
       .in("detail" / path[UUID]("transfer-id"))
@@ -208,6 +222,7 @@ class WebApi(
     requestOutputsRoute,
     requestFailuresRoute,
     reconsiderRoute,
+    reconsiderSingleTransferRoute,
     detailsRoute
   )
 

--- a/manager/src/main/scala/org/broadinstitute/transporter/web/WebApi.scala
+++ b/manager/src/main/scala/org/broadinstitute/transporter/web/WebApi.scala
@@ -221,7 +221,7 @@ class WebApi(
 
   private val reconsiderSingleTransferRoute: Route[(UUID, UUID), ApiError, RequestAck] =
     requestBase
-      .in("reconsider" / path[UUID]("transfer-id"))
+      .in("detail" / path[UUID]("transfer-id") / "reconsider")
       .put
       .out(jsonBody[RequestAck])
       .description(


### PR DESCRIPTION
Add endpoint to reconsider a single transfer (as opposed to all transfers within a request). Adds endpoint, method, helper method, and tests.