### PR TITLE
Ra dspdc 359 get list of transfer IDs for a request ID

### DIFF
--- a/manager/README.md
+++ b/manager/README.md
@@ -51,7 +51,7 @@ Paths below prefixed with `/api/transporter/v1/transfers/{request-id}`.
 | ---- | ---- | ----------- |
 | PUT | `/detail/{transfer-id}/reconsider` | Reset the state of a specific failed transfer in a request to 'Pending'. |
 | GET | `/detail/{transfer-id}` | Get all information stored by the Manager about a specific transfer under a bulk request. |
-| GET | `/list` | Get the transfer IDs for a given request ID which fall within a specified page range. |
+| GET | `/list-transfers` | Get the transfer IDs for a given request ID which fall within a specified page range. |
 
 ## Running Locally
 To run the Manager locally:

--- a/manager/README.md
+++ b/manager/README.md
@@ -38,6 +38,7 @@ Paths below prefixed with `/api/transporter/v1`.
 | Verb | Path | Description |
 | ---- | ---- | ----------- |
 | POST | `/transfers` | Submit a new batch of transfer requests. Validates requests and records them in the DB, but _doesn't_ submit them to Kafka. |
+| GET | `/transfers` | Get summaries of all batch requests stored by Transporter which fall within a specified page range. |
 | GET | `/transfers/{request-id}/status` | Get summary-level status of a transfer request. |
 | GET | `/transfers/{request-id}/outputs` | Get agent-reported outputs of transfers that succeeded within a request. |
 | GET | `/transfers/{request-id}/failures` | Get agent-reported error messages of transfers that failed within a request. |
@@ -50,6 +51,7 @@ Paths below prefixed with `/api/transporter/v1/transfers/{request-id}`.
 | ---- | ---- | ----------- |
 | PUT | `/detail/{transfer-id}/reconsider` | Reset the state of a specific failed transfer in a request to 'Pending'. |
 | GET | `/detail/{transfer-id}` | Get all information stored by the Manager about a specific transfer under a bulk request. |
+| GET | `/list` | Get the transfer IDs for a given request ID which fall within a specified page range. |
 
 ## Running Locally
 To run the Manager locally:

--- a/manager/src/main/scala/org/broadinstitute/transporter/transfer/TransferController.scala
+++ b/manager/src/main/scala/org/broadinstitute/transporter/transfer/TransferController.scala
@@ -346,10 +346,10 @@ class TransferController(
     }
 
   /** Get the total number of transfers stored by Transporter. */
-  def CountTransfers(requestId: UUID): IO[Long] =
+  def countTransfers(requestId: UUID): IO[Long] =
     List(
       fr"select count(1) from",
-      Fragment.const(s"$TransfersTable"),
+      Fragment.const(TransfersTable),
       fr"where request_id = $requestId"
     ).combineAll
       .query[Long]
@@ -357,7 +357,7 @@ class TransferController(
       .transact(dbClient)
 
   /**
-    * For a request ID, page #, and IDs per page, return the list of associated transfer IDs. Page order should match
+    * For a request ID, page #, and IDs per page, return the list of associated transfer IDs. Page order will match
     * the order of the input batch.
     */
   def listTransfers(

--- a/manager/src/main/scala/org/broadinstitute/transporter/transfer/TransferController.scala
+++ b/manager/src/main/scala/org/broadinstitute/transporter/transfer/TransferController.scala
@@ -334,18 +334,42 @@ class TransferController(
     requestId: UUID,
     transferId: UUID
   ): IO[TransferDetails] =
-    for {
-      maybeDetails <- checkAndExec(requestId) { rId =>
-        List(
-          fr"select t.id, t.status, t.body, t.submitted_at, t.updated_at, t.info from",
-          TransfersJoinTable,
-          Fragments.whereAnd(fr"r.id = $rId", fr"t.id = $transferId")
-        ).combineAll
-          .query[TransferDetails]
-          .option
-      }
-      details <- maybeDetails.liftTo[IO](NotFound(requestId, Some(transferId)))
-    } yield {
-      details
+    checkAndExec(requestId, transferId) { (rId, tId) =>
+      List(
+        fr"select t.id, t.status, t.body, t.submitted_at, t.updated_at, t.info from",
+        TransfersJoinTable,
+        Fragments.whereAnd(fr"r.id = $rId", fr"t.id = $tId")
+      ).combineAll
+        .query[TransferDetails]
+        .unique
     }
+
+  /** Get the total number of transfers stored by Transporter. */
+  def CountTransfers: IO[Long] =
+    Fragment
+      .const(s"select count(1) from $TransfersTable")
+      .query[Long]
+      .unique
+      .transact(dbClient)
+
+  /**
+    * For a request ID, page #, and IDs per page, return the list of associated transfer IDs. Page order should match
+    * the order of the input batch.
+    */
+  def listTransfers(
+    requestId: UUID,
+    offset: Long,
+    limit: Long,
+    newestFirst: Boolean
+  ): IO[List[TransferDetails]] =
+    checkAndExec(requestId) { rId =>
+      val order = Fragment.const(if (newestFirst) "desc" else "asc")
+      List(
+        fr"select id, status, body, submitted_at, updated_at, info from $TransfersTable",
+        fr"where request_id = $rId order by id " ++ order ++ fr" limit $limit offset $offset"
+      ).combineAll
+        .query[TransferDetails]
+        .to[List]
+    }
+
 }

--- a/manager/src/main/scala/org/broadinstitute/transporter/web/WebApi.scala
+++ b/manager/src/main/scala/org/broadinstitute/transporter/web/WebApi.scala
@@ -217,7 +217,7 @@ class WebApi(
     .in(query[SortOrder]("sort"))
     .out(jsonBody[Page[TransferDetails]])
     .description(
-      "Get the transfer IDs for a given request ID, page number, and number of transfer IDs per page"
+      "Get transfer details for a given request"
     )
     .serverLogic {
       case (requestId, offset, limit, sort) =>

--- a/manager/src/main/scala/org/broadinstitute/transporter/web/WebApi.scala
+++ b/manager/src/main/scala/org/broadinstitute/transporter/web/WebApi.scala
@@ -227,7 +227,7 @@ class WebApi(
           limit,
           sortDesc = sort == SortOrder.Desc
         )
-        val getTotal = transferController.CountTransfers(requestId)
+        val getTotal = transferController.countTransfers(requestId)
         buildResponse(
           (getPage, getTotal).parMapN { case (items, total) => Page(items, total) },
           s"Failed to list transfers for request ID $requestId"

--- a/manager/src/main/scala/org/broadinstitute/transporter/web/WebApi.scala
+++ b/manager/src/main/scala/org/broadinstitute/transporter/web/WebApi.scala
@@ -211,6 +211,7 @@ class WebApi(
     ApiError,
     Page[TransferDetails]
   ] = singleRequestBase
+    .in("list-transfers")
     .in(query[Long]("offset"))
     .in(query[Long]("limit"))
     .in(query[SortOrder]("sort"))

--- a/manager/src/test/scala/org/broadinstitute/transporter/transfer/TransferControllerSpec.scala
+++ b/manager/src/test/scala/org/broadinstitute/transporter/transfer/TransferControllerSpec.scala
@@ -513,7 +513,7 @@ class TransferControllerSpec extends PostgresSpec with MockFactory with EitherVa
   }
 
   it should "count all tracked transfers" in withRequest { (_, controller) =>
-    controller.CountTransfers(request1Id).map(_ shouldBe 10)
+    controller.countTransfers(request1Id).map(_ shouldBe 10)
   }
 
   it should "get details for multiple transfers" in withRequest { (tx, controller) =>

--- a/manager/src/test/scala/org/broadinstitute/transporter/transfer/TransferControllerSpec.scala
+++ b/manager/src/test/scala/org/broadinstitute/transporter/transfer/TransferControllerSpec.scala
@@ -494,11 +494,12 @@ class TransferControllerSpec extends PostgresSpec with MockFactory with EitherVa
   }
 
   it should "fail to get details under a nonexistent request" in withController {
+    val transferId = UUID.randomUUID()
     (_, controller) =>
       controller
-        .lookupTransferDetails(request1Id, UUID.randomUUID())
+        .lookupTransferDetails(request1Id, transferId)
         .attempt
-        .map(_.left.value shouldBe NotFound(request1Id))
+        .map(_.left.value shouldBe NotFound(request1Id, Some(transferId)))
   }
 
   it should "fail to get details for a nonexistent transfer" in withRequest {

--- a/manager/src/test/scala/org/broadinstitute/transporter/transfer/TransferControllerSpec.scala
+++ b/manager/src/test/scala/org/broadinstitute/transporter/transfer/TransferControllerSpec.scala
@@ -511,4 +511,135 @@ class TransferControllerSpec extends PostgresSpec with MockFactory with EitherVa
           _.left.value shouldBe NotFound(request1Id, Some(request2Transfers.head._1))
         )
   }
+
+  it should "count all tracked transfers" in withRequest { (_, controller) =>
+    controller.CountTransfers(request1Id).map(_ shouldBe 10)
+  }
+
+  it should "get details for multiple transfers" in withRequest { (tx, controller) =>
+    val request1TransfersSorted = request1Transfers.sortBy(_._1.toString)
+    val (id1, body1) = request1TransfersSorted(2)
+    val (id2, body2) = request1TransfersSorted(3)
+    val submitted = Instant.now()
+    val updated = submitted.plusMillis(30000)
+
+    for {
+      initInfo <- controller.listTransfers(request1Id, 2, 2, sortDesc = false)
+      _ <- sql"""update transfers set
+                 status = ${TransferStatus.Submitted: TransferStatus},
+                 submitted_at = ${Timestamp.from(submitted)}
+                 where id = $id1""".update.run.void.transact(tx)
+      _ <- sql"""update transfers set
+                 status = ${TransferStatus.Submitted: TransferStatus},
+                 submitted_at = ${Timestamp.from(submitted)}
+                 where id = $id2""".update.run.void.transact(tx)
+      submittedInfo <- controller.listTransfers(request1Id, 2, 2, sortDesc = false)
+      _ <- sql"""update transfers set
+                 status = ${TransferStatus.Succeeded: TransferStatus},
+                 updated_at = ${Timestamp.from(updated)},
+                 info = '{}'
+                 where id = $id1""".update.run.void.transact(tx)
+      _ <- sql"""update transfers set
+                 status = ${TransferStatus.Succeeded: TransferStatus},
+                 updated_at = ${Timestamp.from(updated)},
+                 info = '{}'
+                 where id = $id2""".update.run.void.transact(tx)
+      updatedInfo <- controller.listTransfers(request1Id, 2, 2, sortDesc = false)
+    } yield {
+      initInfo shouldBe List(
+        TransferDetails(
+          id1,
+          TransferStatus.Pending,
+          body1,
+          None,
+          None,
+          None
+        ),
+        TransferDetails(
+          id2,
+          TransferStatus.Pending,
+          body2,
+          None,
+          None,
+          None
+        )
+      )
+      submittedInfo shouldBe List(
+        TransferDetails(
+          id1,
+          TransferStatus.Submitted,
+          body1,
+          Some(OffsetDateTime.ofInstant(submitted, ZoneId.of("UTC"))),
+          None,
+          None
+        ),
+        TransferDetails(
+          id2,
+          TransferStatus.Submitted,
+          body2,
+          Some(OffsetDateTime.ofInstant(submitted, ZoneId.of("UTC"))),
+          None,
+          None
+        )
+      )
+      updatedInfo shouldBe List(
+        TransferDetails(
+          id1,
+          TransferStatus.Succeeded,
+          body1,
+          Some(OffsetDateTime.ofInstant(submitted, ZoneId.of("UTC"))),
+          Some(OffsetDateTime.ofInstant(updated, ZoneId.of("UTC"))),
+          Some(json"{}")
+        ),
+        TransferDetails(
+          id2,
+          TransferStatus.Succeeded,
+          body2,
+          Some(OffsetDateTime.ofInstant(submitted, ZoneId.of("UTC"))),
+          Some(OffsetDateTime.ofInstant(updated, ZoneId.of("UTC"))),
+          Some(json"{}")
+        )
+      )
+    }
+  }
+
+  it should "return an empty list if the limit is 0" in withRequest { (tx, controller) =>
+    val (id1, _) = request1Transfers.head
+    val submitted = Instant.now()
+
+    for {
+      _ <- sql"""update transfers set
+                 status = ${TransferStatus.Submitted: TransferStatus},
+                 submitted_at = ${Timestamp.from(submitted)}
+                 where id = $id1""".update.run.void.transact(tx)
+      theInfo <- controller.listTransfers(request1Id, 2, 0, sortDesc = false)
+    } yield {
+      theInfo shouldBe List()
+    }
+  }
+
+  it should "return an empty list if the offset is beyond what exists in the table" in withRequest {
+    (tx, controller) =>
+      val (id1, _) = request1Transfers.head
+      val submitted = Instant.now()
+
+      for {
+        _ <- sql"""update transfers set
+                 status = ${TransferStatus.Submitted: TransferStatus},
+                 submitted_at = ${Timestamp.from(submitted)}
+                 where id = $id1""".update.run.void.transact(tx)
+        theInfo <- controller.listTransfers(request1Id, 100, 2, sortDesc = false)
+      } yield {
+        theInfo shouldBe List()
+      }
+  }
+
+  it should "fail to get details for multiple transfers under a nonexistent request" in withController {
+    val requestId = UUID.randomUUID()
+    (_, controller) =>
+      controller
+        .listTransfers(requestId, 2, 2, sortDesc = true)
+        .attempt
+        .map(_.left.value shouldBe NotFound(requestId))
+  }
 }


### PR DESCRIPTION
Added methods to list the transfer IDs for a request ID with pagination (offset/limit in SQL) and sorting, a method to count the transfers for a request so as to parallelize things, added an endpoint for listing the transfer IDs, and updated the ReadMe with this endpoint as well as Dan's endpoint for listing requests.