### PR TITLE
DSPDC-569 Add escape hatch for overriding max message size.

### DIFF
--- a/agents/sftp-to-gcs/deploy/init-containers/transporter-sftp-to-gcs-agent/application.conf.ctmpl
+++ b/agents/sftp-to-gcs/deploy/init-containers/transporter-sftp-to-gcs-agent/application.conf.ctmpl
@@ -3,6 +3,7 @@ org.broadinstitute.transporter {
     kafka {
         bootstrap-servers = ["{{env "KAFKA_BOOTSTRAP_URL"}}"]
         application-id = "{{env "KAFKA_APPLICATION_ID"}}"
+        max-message-size-mib = {{env "KAFKA_MAX_MESSAGE_SIZE_MIB"}}
 
         topics {
             request-topic = "{{env "REQUEST_TOPIC"}}"

--- a/agents/template/src/main/resources/reference.conf
+++ b/agents/template/src/main/resources/reference.conf
@@ -3,6 +3,7 @@ org.broadinstitute.transporter {
 
   kafka {
     bootstrap-servers: ["localhost:9092"]
+    max-message-size-mib: null
 
     # Fill this in for specific agents.
     # It should be the same for every replica of an agent type.

--- a/agents/template/src/test/scala/org/broadinstitute/transporter/kafka/TransferStreamBuilderSpec.scala
+++ b/agents/template/src/test/scala/org/broadinstitute/transporter/kafka/TransferStreamBuilderSpec.scala
@@ -77,6 +77,7 @@ class TransferStreamBuilderSpec
     val config = KStreamsConfig(
       "test-app",
       List(s"localhost:${baseConfig.kafkaPort}"),
+      None,
       topics,
       tls = None,
       scram = None


### PR DESCRIPTION
Note that this only adds the toggle to the producer side, and not the consumer side. That's all that was needed to get the in-flight transfers un-stuck, but we might hit problems in the future.