### PR TITLE
Ra dspdc 531 status filter

### DIFF
--- a/manager/README.md
+++ b/manager/README.md
@@ -40,8 +40,6 @@ Paths below prefixed with `/api/transporter/v1`.
 | POST | `/transfers` | Submit a new batch of transfer requests. Validates requests and records them in the DB, but _doesn't_ submit them to Kafka. |
 | GET | `/transfers` | Get summaries of all batch requests stored by Transporter which fall within a specified page range. |
 | GET | `/transfers/{request-id}/status` | Get summary-level status of a transfer request. |
-| GET | `/transfers/{request-id}/outputs` | Get agent-reported outputs of transfers that succeeded within a request. |
-| GET | `/transfers/{request-id}/failures` | Get agent-reported error messages of transfers that failed within a request. |
 | PUT | `/transfers/{request-id}/reconsider` | Reset the state of all failed transfers in a request to 'Pending'. |
 | PUT | `/transfers/{request-id}/priority` | Update the priority of all pending transfers in a request. |
 

--- a/manager/src/main/scala/org/broadinstitute/transporter/transfer/TransferController.scala
+++ b/manager/src/main/scala/org/broadinstitute/transporter/transfer/TransferController.scala
@@ -286,42 +286,6 @@ class TransferController(
     checkAndExec(requestId)(rId => lookupSummaries(List(rId)).map(_.head))
 
   /**
-    * Get the JSON payloads returned by agents for successfully-completed transfers
-    * under a request.
-    */
-  def lookupRequestOutputs(requestId: UUID): IO[RequestInfo] =
-    lookupRequestInfo(requestId, TransferStatus.Succeeded)
-
-  /**
-    * Get the JSON payloads returned by agents for failed transfers
-    * under a request.
-    */
-  def lookupRequestFailures(requestId: UUID): IO[RequestInfo] =
-    lookupRequestInfo(requestId, TransferStatus.Failed)
-
-  /**
-    * Get any information collected by the manager from transfers under a previously-submitted
-    * request which have a given status.
-    */
-  private def lookupRequestInfo(
-    requestId: UUID,
-    status: TransferStatus
-  ): IO[RequestInfo] =
-    checkAndExec(requestId) { rId =>
-      List(
-        fr"SELECT t.id, t.info FROM",
-        TransfersJoinTable,
-        Fragments.whereAnd(
-          fr"r.id = $rId",
-          fr"t.status = $status",
-          fr"t.info IS NOT NULL"
-        )
-      ).combineAll
-        .query[TransferInfo]
-        .to[List]
-    }.map(RequestInfo(requestId, _))
-
-  /**
     * Reset the statuses for all failed transfers under a request to 'pending',
     * so that they will be re-submitted by the periodic sweeper.
     */

--- a/manager/src/main/scala/org/broadinstitute/transporter/transfer/TransferController.scala
+++ b/manager/src/main/scala/org/broadinstitute/transporter/transfer/TransferController.scala
@@ -394,7 +394,7 @@ class TransferController(
     offset: Long,
     limit: Long,
     sortDesc: Boolean,
-    status: Option[TransferStatus]
+    status: Option[TransferStatus] = None
   ): IO[List[TransferDetails]] =
     checkAndExec(requestId) { rId =>
       val order = Fragment.const(if (sortDesc) "desc" else "asc")

--- a/manager/src/main/scala/org/broadinstitute/transporter/web/WebApi.scala
+++ b/manager/src/main/scala/org/broadinstitute/transporter/web/WebApi.scala
@@ -234,48 +234,6 @@ class WebApi(
         )
       }
 
-  private val requestOutputsRoute: Route[UUID, ApiError, RequestInfo] =
-    singleRequestBase.get
-      .in("outputs")
-      .out(jsonBody[RequestInfo])
-      .errorOut(
-        oneOf(
-          statusMapping(StatusCodes.NotFound, jsonBody[ApiError.NotFound]),
-          statusMapping(
-            StatusCodes.InternalServerError,
-            jsonBody[ApiError.UnhandledError]
-          )
-        )
-      )
-      .description("Get the outputs of successful transfers from a request")
-      .serverLogic { requestId =>
-        buildResponse(
-          transferController.lookupRequestOutputs(requestId),
-          s"Failed to look up outputs for $requestId"
-        )
-      }
-
-  private val requestFailuresRoute: Route[UUID, ApiError, RequestInfo] =
-    singleRequestBase.get
-      .in("failures")
-      .out(jsonBody[RequestInfo])
-      .errorOut(
-        oneOf(
-          statusMapping(StatusCodes.NotFound, jsonBody[ApiError.NotFound]),
-          statusMapping(
-            StatusCodes.InternalServerError,
-            jsonBody[ApiError.UnhandledError]
-          )
-        )
-      )
-      .description("Get the outputs of failed transfers from a request")
-      .serverLogic { requestId =>
-        buildResponse(
-          transferController.lookupRequestFailures(requestId),
-          s"Failed to look up failures for $requestId"
-        )
-      }
-
   private val lookupTransfersRoute: Route[
     (UUID, Long, Long, SortOrder, Option[TransferStatus]),
     ApiError,
@@ -391,8 +349,6 @@ class WebApi(
     updateRequestPriorityRoute,
     updateTransferPriorityRoute,
     requestStatusRoute,
-    requestOutputsRoute,
-    requestFailuresRoute,
     lookupTransfersRoute,
     reconsiderRoute,
     reconsiderSingleTransferRoute,

--- a/manager/src/test/scala/org/broadinstitute/transporter/transfer/TransferControllerSpec.scala
+++ b/manager/src/test/scala/org/broadinstitute/transporter/transfer/TransferControllerSpec.scala
@@ -753,6 +753,30 @@ class TransferControllerSpec extends PostgresSpec with MockFactory with EitherVa
         .map(_.left.value shouldBe NotFound(requestId))
   }
 
+  it should "only list transfers filtered to a specified status" in withRequest {
+    (_, controller) =>
+      val limit = 5
+      for {
+        info <- controller.listTransfers(
+          request1Id,
+          0,
+          limit.toLong,
+          sortDesc = false,
+          Option(TransferStatus.Pending)
+        )
+        emptyInfo <- controller.listTransfers(
+          request1Id,
+          0,
+          limit.toLong,
+          sortDesc = false,
+          Option(TransferStatus.Expanded)
+        )
+      } yield {
+        info.length shouldBe List(request1Transfers.length, limit).min
+        emptyInfo.isEmpty shouldBe true
+      }
+  }
+
   it should "update the priority for all transfers in a request" in withRequest {
     (tx, controller) =>
       for {


### PR DESCRIPTION
Add a status filter to the list-transfers endpoint and add a test to make sure it works as desired. Remove the outputs and failures endpoints as well as all associated code (methods, tests, endpoints, and from the readme)