### PR TITLE
Allow configuring max bytes per message in non-stream consumers.

### DIFF
--- a/agents/template/src/main/scala/org/broadinstitute/transporter/kafka/KStreamsConfig.scala
+++ b/agents/template/src/main/scala/org/broadinstitute/transporter/kafka/KStreamsConfig.scala
@@ -2,6 +2,7 @@ package org.broadinstitute.transporter.kafka
 
 import java.util.Properties
 
+import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.clients.producer.ProducerConfig
 import org.apache.kafka.streams.StreamsConfig
 import org.apache.kafka.streams.errors.LogAndFailExceptionHandler
@@ -34,7 +35,12 @@ case class KStreamsConfig(
     */
   private[kafka] def asMap: Map[String, String] =
     maxMessageSizeMib.fold(Map.empty[String, String]) { max =>
-      Map(ProducerConfig.MAX_REQUEST_SIZE_CONFIG -> (max * 1024 * 1024).toString)
+      val byteSize = (max * 1024 * 1024).toString
+      Map(
+        ProducerConfig.MAX_REQUEST_SIZE_CONFIG -> byteSize,
+        ConsumerConfig.MAX_PARTITION_FETCH_BYTES_CONFIG -> byteSize,
+        ConsumerConfig.FETCH_MAX_BYTES_CONFIG -> byteSize
+      )
     } ++ ConnectionConfig.securityProperties(tls, scram) ++ Map(
       StreamsConfig.APPLICATION_ID_CONFIG -> applicationId,
       StreamsConfig.BOOTSTRAP_SERVERS_CONFIG -> bootstrapServers.mkString(","),

--- a/common/src/main/scala/org/broadinstitute/transporter/kafka/config/ConsumerConfig.scala
+++ b/common/src/main/scala/org/broadinstitute/transporter/kafka/config/ConsumerConfig.scala
@@ -13,11 +13,13 @@ import scala.concurrent.duration.FiniteDuration
   *                           before emitting to downstream processing
   * @param waitTimePerBatch max time consumers should wait for new records before
   *                         emitting to downstream processing
+  * @param maxMessageSizeMib max bytes to pull as a single message
   */
 case class ConsumerConfig(
   groupId: String,
   maxRecordsPerBatch: Int,
-  waitTimePerBatch: FiniteDuration
+  waitTimePerBatch: FiniteDuration,
+  maxMessageSizeMib: Option[Int]
 )
 
 object ConsumerConfig {

--- a/common/src/test/scala/org/broadinstitute/transporter/kafka/KafkaConsumerSpec.scala
+++ b/common/src/test/scala/org/broadinstitute/transporter/kafka/KafkaConsumerSpec.scala
@@ -21,7 +21,7 @@ class KafkaConsumerSpec extends BaseKafkaSpec with EitherValues {
 
   private val topic = "the-topic"
 
-  private val consumerConfig = ConsumerConfig("test-group", 3, 500.millis)
+  private val consumerConfig = ConsumerConfig("test-group", 3, 500.millis, None)
 
   behavior of "KafkaConsumer"
 

--- a/manager/deploy/init-containers/transporter-manager/application.conf.ctmpl
+++ b/manager/deploy/init-containers/transporter-manager/application.conf.ctmpl
@@ -23,7 +23,10 @@ org.broadinstitute.transporter {
                 hash-algorithm = "{{env "KAFKA_SCRAM_ALGORITHM"}}"
             }
         }
-        consumer.group-id = "{{env "KAFKA_GROUP_ID"}}"
+        consumer {
+            group-id = "{{env "KAFKA_GROUP_ID"}}"
+            max-message-size-mib = {{env "MIB_PER_TRANSFER_STEP"}}
+        }
 
         topics {
             request-topic = {{env "REQUEST_TOPIC"}}

--- a/manager/src/main/resources/reference.conf
+++ b/manager/src/main/resources/reference.conf
@@ -42,6 +42,7 @@ org.broadinstitute.transporter {
       group-id: "transporter-manager"
       max-records-per-batch: 100
       wait-time-per-batch: 1s
+      max-message-size-mib: null
     }
 
     topics {


### PR DESCRIPTION
The hotfix in #58 enabled toggling max message size on the agent side, but not in the manager. That was enough to get the transfer un-stuck so I left it while I was gone, but I wanted to close the loop here.