### PR TITLE
DSPDC-582 Collection of updates for AnVIL tuning

### DIFF
--- a/agents/sftp-to-gcs/deploy/init-containers/transporter-sftp-to-gcs-agent/application.conf.ctmpl
+++ b/agents/sftp-to-gcs/deploy/init-containers/transporter-sftp-to-gcs-agent/application.conf.ctmpl
@@ -24,6 +24,7 @@ org.broadinstitute.transporter {
 
     runner-config {
         mib-per-step = {{env "MIB_PER_TRANSFER_STEP"}}
+        max-concurrent-reads = {{env "MAX_CONCURRENT_READS"}}
 
         sftp {
             host = "{{env "SFTP_HOST"}}"

--- a/agents/sftp-to-gcs/src/main/resources/reference.conf
+++ b/agents/sftp-to-gcs/src/main/resources/reference.conf
@@ -3,6 +3,7 @@ org.broadinstitute.transporter {
 
   runner-config {
     mib-per-step: 5
+    max-concurrent-reads: 128
 
     gcs-service-account: null
 

--- a/agents/sftp-to-gcs/src/main/scala/org/broadinstitute/transporter/config/RunnerConfig.scala
+++ b/agents/sftp-to-gcs/src/main/scala/org/broadinstitute/transporter/config/RunnerConfig.scala
@@ -12,7 +12,8 @@ case class RunnerConfig(
   gcsServiceAccount: Option[Path],
   timeouts: TimeoutConfig,
   retries: RetryConfig,
-  mibPerStep: Int
+  mibPerStep: Int,
+  maxConcurrentReads: Int
 )
 
 object RunnerConfig {

--- a/agents/sftp-to-gcs/src/main/scala/org/broadinstitute/transporter/transfer/SftpToGcsRunner.scala
+++ b/agents/sftp-to-gcs/src/main/scala/org/broadinstitute/transporter/transfer/SftpToGcsRunner.scala
@@ -180,7 +180,9 @@ object SftpToGcsRunner {
       config.sftp,
       blocker,
       maxRetries = config.retries.maxRetries,
-      retryDelay = config.retries.maxDelay
+      retryDelay = config.retries.maxDelay,
+      // YOLO
+      readAhead = Int.MaxValue
     )
 
     val gcs = BlazeClientBuilder[IO](ec)

--- a/agents/sftp-to-gcs/src/main/scala/org/broadinstitute/transporter/transfer/SftpToGcsRunner.scala
+++ b/agents/sftp-to-gcs/src/main/scala/org/broadinstitute/transporter/transfer/SftpToGcsRunner.scala
@@ -181,8 +181,7 @@ object SftpToGcsRunner {
       blocker,
       maxRetries = config.retries.maxRetries,
       retryDelay = config.retries.maxDelay,
-      // YOLO
-      readAhead = Int.MaxValue
+      readAhead = config.maxConcurrentReads
     )
 
     val gcs = BlazeClientBuilder[IO](ec)

--- a/agents/sftp-to-gcs/src/main/scala/org/broadinstitute/transporter/transfer/SftpToGcsRunner.scala
+++ b/agents/sftp-to-gcs/src/main/scala/org/broadinstitute/transporter/transfer/SftpToGcsRunner.scala
@@ -180,7 +180,7 @@ object SftpToGcsRunner {
     val sftp = SshjSftpApi.build(
       config.sftp,
       blocker,
-      readChunkSize = 256 * bytesPerKib,
+      readChunkSize = 32 * bytesPerKib,
       maxRetries = config.retries.maxRetries,
       retryDelay = config.retries.maxDelay,
       readAhead = config.maxConcurrentReads

--- a/agents/template/src/main/scala/org/broadinstitute/transporter/kafka/TransferStreamBuilder.scala
+++ b/agents/template/src/main/scala/org/broadinstitute/transporter/kafka/TransferStreamBuilder.scala
@@ -80,7 +80,7 @@ class TransferStreamBuilder[I: Decoder, P: Encoder: Decoder, O: Encoder](
                 logger.warn(err)(
                   s"Unhandled error initializing transfer ${ids.transfer} from request ${ids.request}"
                 )
-                Failure(err)
+                Failure("Unhandled error initializing transfer", err)
               },
               identity
             )
@@ -139,7 +139,7 @@ class TransferStreamBuilder[I: Decoder, P: Encoder: Decoder, O: Encoder](
                   logger.warn(err)(
                     s"Unhandled error running step on transfer ${ids.transfer} from request ${ids.request}"
                   )
-                  Failure(err)
+                  Failure("Unhandled error running step on transfer", err)
                 },
                 identity
               )

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ val doobieVersion = "0.8.4"
 val postgresqlDriverVersion = "42.2.5"
 
 // JSON.
-val circeVersion = "0.12.2"
+val circeVersion = "0.12.3"
 val circeDerivationVersion = "0.12.0-M7"
 val enumeratumCirceVersion = "1.5.22"
 val everitJsonSchemaVersion = "1.12.0"

--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,7 @@ val googleAuthVersion = "0.18.0"
 val enumeratumVersion = "1.5.13"
 
 // Web.
-val storageLibsVersion = "0.5.0-2-26e83d37-SNAPSHOT"
+val storageLibsVersion = "0.6.0"
 val http4sVersion = "0.21.0-M5"
 val swaggerUiModule = "swagger-ui"
 val swaggerUiVersion = "3.24.0"

--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,7 @@ val googleAuthVersion = "0.18.0"
 val enumeratumVersion = "1.5.13"
 
 // Web.
-val storageLibsVersion = "0.5.0"
+val storageLibsVersion = "0.5.0-2-26e83d37-SNAPSHOT"
 val http4sVersion = "0.21.0-M5"
 val swaggerUiModule = "swagger-ui"
 val swaggerUiVersion = "3.24.0"

--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,7 @@ val enumeratumVersion = "1.5.13"
 val storageLibsVersion = "0.5.0"
 val http4sVersion = "0.21.0-M5"
 val swaggerUiModule = "swagger-ui"
-val swaggerUiVersion = "3.23.8"
+val swaggerUiVersion = "3.24.0"
 val tapirVersion = "0.11.6"
 
 // Testing.

--- a/manager/src/main/scala/org/broadinstitute/transporter/transfer/TransferController.scala
+++ b/manager/src/main/scala/org/broadinstitute/transporter/transfer/TransferController.scala
@@ -339,11 +339,14 @@ class TransferController(
     }
 
   /** Get the total number of transfers stored by Transporter. */
-  def countTransfers(requestId: UUID): IO[Long] =
+  def countTransfers(requestId: UUID, status: Option[TransferStatus] = None): IO[Long] =
     List(
       fr"SELECT COUNT(1) FROM",
       Fragment.const(TransfersTable),
-      fr"WHERE request_id = $requestId"
+      Fragments.whereAndOpt(
+        Some(fr"request_id = $requestId"),
+        status.map(s => fr"status = $s")
+      )
     ).combineAll
       .query[Long]
       .unique

--- a/manager/src/main/scala/org/broadinstitute/transporter/web/WebApi.scala
+++ b/manager/src/main/scala/org/broadinstitute/transporter/web/WebApi.scala
@@ -107,8 +107,8 @@ class WebApi(
     ApiError,
     Page[RequestSummary]
   ] = batchesBase.get
-    .in(query[Long]("offset"))
-    .in(query[Long]("limit"))
+    .in(query[Long]("offset").example(0L))
+    .in(query[Long]("limit").example(10L))
     .in(query[SortOrder]("sort"))
     .out(jsonBody[Page[RequestSummary]])
     .errorOut(
@@ -130,7 +130,9 @@ class WebApi(
         val getTotal = transferController.countRequests
 
         buildResponse(
-          (getPage, getTotal).parMapN { case (items, total) => Page(items, total) },
+          (getPage, getTotal).parMapN {
+            case (items, total) => Page(items, total)
+          },
           "Failed to list transfer batches"
         )
     }
@@ -141,7 +143,10 @@ class WebApi(
       .out(jsonBody[RequestAck])
       .errorOut(
         oneOf(
-          statusMapping(StatusCodes.BadRequest, jsonBody[ApiError.InvalidRequest]),
+          statusMapping(
+            StatusCodes.BadRequest,
+            jsonBody[ApiError.InvalidRequest]
+          ),
           statusMapping(
             StatusCodes.InternalServerError,
             jsonBody[ApiError.UnhandledError]
@@ -215,7 +220,9 @@ class WebApi(
           )
         )
       )
-      .summary("Reset the state of all failed transfers in a batch to 'pending'")
+      .summary(
+        "Reset the state of all failed transfers in a batch to 'pending'"
+      )
       .serverLogic { requestId =>
         buildResponse(
           transferController.reconsiderRequest(requestId),
@@ -233,8 +240,8 @@ class WebApi(
     ApiError,
     Page[TransferDetails]
   ] = transfersBase.get
-    .in(query[Long]("offset"))
-    .in(query[Long]("limit"))
+    .in(query[Long]("offset").example(0L))
+    .in(query[Long]("limit").example(10L))
     .in(query[SortOrder]("sort"))
     .in(query[Option[TransferStatus]]("status"))
     .out(jsonBody[Page[TransferDetails]])
@@ -259,7 +266,9 @@ class WebApi(
         )
         val getTotal = transferController.countTransfers(requestId)
         buildResponse(
-          (getPage, getTotal).parMapN { case (items, total) => Page(items, total) },
+          (getPage, getTotal).parMapN {
+            case (items, total) => Page(items, total)
+          },
           s"Failed to list transfers of batch $requestId"
         )
     }
@@ -309,7 +318,8 @@ class WebApi(
     .serverLogic {
       case (requestId, transferId, priority) =>
         buildResponse(
-          transferController.updateTransferPriority(requestId, transferId, priority),
+          transferController
+            .updateTransferPriority(requestId, transferId, priority),
           s"Failed to update priority for transfer $transferId"
         )
     }
@@ -383,7 +393,8 @@ class WebApi(
         components.copy(securitySchemes = labeledScheme)
       }
 
-      val pathSecurity = List(ListMap(OAuthConfig.AuthName -> OAuthConfig.AuthScopes))
+      val pathSecurity =
+        List(ListMap(OAuthConfig.AuthName -> OAuthConfig.AuthScopes))
       def addSecurity(op: Option[Operation]): Option[Operation] =
         op.map(_.copy(security = pathSecurity))
 
@@ -555,14 +566,21 @@ object WebApi {
   implicit def enumSchema[E <: EnumEntry: Enum]: SchemaFor[E] =
     SchemaFor(Schema.SString)
 
-  implicit def enumCodec[E <: EnumEntry](implicit E: Enum[E]): Codec.PlainCodec[E] =
+  implicit def enumCodec[E <: EnumEntry](
+    implicit E: Enum[E]
+  ): Codec.PlainCodec[E] =
     Codec.stringPlainCodecUtf8.mapDecode { s =>
       E.namesToValuesMap.get(s) match {
         case Some(e) => DecodeResult.Value(e)
         case None =>
-          DecodeResult.Mismatch(s"One of: ${E.values.map(_.entryName).mkString(",")}", s)
+          DecodeResult.Mismatch(
+            s"One of: ${E.values.map(_.entryName).mkString(",")}",
+            s
+          )
       }
-    }(_.entryName).schema(enumSchema[E].schema)
+    }(_.entryName)
+      .schema(enumSchema[E].schema)
+      .validate(Validator.`enum`(E.values.toList))
 
   implicit def enumMapSchema[E <: EnumEntry, V](
     implicit e: Enum[E],

--- a/manager/src/main/scala/org/broadinstitute/transporter/web/WebApi.scala
+++ b/manager/src/main/scala/org/broadinstitute/transporter/web/WebApi.scala
@@ -264,7 +264,7 @@ class WebApi(
           sortDesc = sort == SortOrder.Desc,
           status
         )
-        val getTotal = transferController.countTransfers(requestId)
+        val getTotal = transferController.countTransfers(requestId, status)
         buildResponse(
           (getPage, getTotal).parMapN {
             case (items, total) => Page(items, total)


### PR DESCRIPTION
* Pull in our new SFTP read-ahead logic, and expose the parallelism factor as a parameter
* Run download and upload streams concurrently within the agent
* Include messages of causal exceptions in failure payloads when possible
* Filter total transfer counts when listing transfers by status
* Fill in default values for Swagger
* Twiddle some chunk sizes