### PR TITLE
Update Swagger UI for post requests

### DIFF
--- a/manager/src/main/scala/org/broadinstitute/transporter/TransporterManager.scala
+++ b/manager/src/main/scala/org/broadinstitute/transporter/TransporterManager.scala
@@ -54,7 +54,8 @@ object TransporterManager extends IOApp.WithContext {
             new InfoController(TransporterManagerBuildInfo.version, transactor),
             controller,
             googleAuthConfig = config.web.googleOauth,
-            blockingEc = blockingEc
+            blockingEc = blockingEc,
+            config.transfer.schema.json
           )
 
           val server = BlazeServerBuilder[IO]

--- a/manager/src/main/scala/org/broadinstitute/transporter/TransporterManager.scala
+++ b/manager/src/main/scala/org/broadinstitute/transporter/TransporterManager.scala
@@ -55,7 +55,7 @@ object TransporterManager extends IOApp.WithContext {
             controller,
             googleAuthConfig = config.web.googleOauth,
             blockingEc = blockingEc,
-            config.transfer.schema.json
+            transferSchema = config.transfer.schema
           )
 
           val server = BlazeServerBuilder[IO]

--- a/manager/src/main/scala/org/broadinstitute/transporter/transfer/config/TransferSchema.scala
+++ b/manager/src/main/scala/org/broadinstitute/transporter/transfer/config/TransferSchema.scala
@@ -26,7 +26,7 @@ import scala.collection.JavaConverters._
   *                  to the specified rules
   */
 class TransferSchema private (
-  private val json: Json,
+  val json: Json,
   private[this] val validator: Schema
 ) {
 

--- a/manager/src/main/scala/org/broadinstitute/transporter/transfer/config/TransferSchema.scala
+++ b/manager/src/main/scala/org/broadinstitute/transporter/transfer/config/TransferSchema.scala
@@ -57,18 +57,10 @@ class TransferSchema private (
 
   override def toString: String = json.spaces2
 
-  def asExample: BulkRequest = {
-    val batchPostExampleTransfer: TransferRequest = TransferRequest(
-      json.findAllByKey("properties").head.mapObject { properties =>
-        properties.mapValues(property => property.findAllByKey("type").head)
-      },
-      Option(0.toShort)
-    )
-
-    BulkRequest(
-      List(batchPostExampleTransfer),
-      Option(batchPostExampleTransfer)
-    )
+  def asExample: Json = {
+    json.findAllByKey("properties").head.mapObject { properties =>
+      properties.mapValues(property => property.findAllByKey("type").head)
+    }
   }
 }
 

--- a/manager/src/main/scala/org/broadinstitute/transporter/transfer/config/TransferSchema.scala
+++ b/manager/src/main/scala/org/broadinstitute/transporter/transfer/config/TransferSchema.scala
@@ -6,6 +6,7 @@ import com.typesafe.config.{ConfigList, ConfigObject, ConfigValue, ConfigValueTy
 import io.circe.Decoder.Result
 import io.circe._
 import io.circe.syntax._
+import org.broadinstitute.transporter.transfer.api.{BulkRequest, TransferRequest}
 import org.everit.json.schema.{Schema, ValidationException}
 import org.everit.json.schema.loader.SchemaLoader
 import org.json.{JSONArray, JSONObject, JSONTokener}
@@ -26,7 +27,7 @@ import scala.collection.JavaConverters._
   *                  to the specified rules
   */
 class TransferSchema private (
-  val json: Json,
+  private val json: Json,
   private[this] val validator: Schema
 ) {
 
@@ -55,6 +56,20 @@ class TransferSchema private (
   }
 
   override def toString: String = json.spaces2
+
+  def asExample: BulkRequest = {
+    val batchPostExampleTransfer: TransferRequest = TransferRequest(
+      json.findAllByKey("properties").head.mapObject { properties =>
+        properties.mapValues(property => property.findAllByKey("type").head)
+      },
+      Option(0.toShort)
+    )
+
+    BulkRequest(
+      List(batchPostExampleTransfer),
+      Option(batchPostExampleTransfer)
+    )
+  }
 }
 
 object TransferSchema {

--- a/manager/src/main/scala/org/broadinstitute/transporter/transfer/config/TransferSchema.scala
+++ b/manager/src/main/scala/org/broadinstitute/transporter/transfer/config/TransferSchema.scala
@@ -6,7 +6,6 @@ import com.typesafe.config.{ConfigList, ConfigObject, ConfigValue, ConfigValueTy
 import io.circe.Decoder.Result
 import io.circe._
 import io.circe.syntax._
-import org.broadinstitute.transporter.transfer.api.{BulkRequest, TransferRequest}
 import org.everit.json.schema.{Schema, ValidationException}
 import org.everit.json.schema.loader.SchemaLoader
 import org.json.{JSONArray, JSONObject, JSONTokener}

--- a/manager/src/main/scala/org/broadinstitute/transporter/web/WebApi.scala
+++ b/manager/src/main/scala/org/broadinstitute/transporter/web/WebApi.scala
@@ -140,7 +140,8 @@ class WebApi(
     }
 
   private val postTransferRequestExample: TransferRequest = TransferRequest(
-    transferSchema.asExample, Option(0.toShort)
+    transferSchema.asExample,
+    Option(0.toShort)
   )
 
   private val postBulkRequestExample: BulkRequest = BulkRequest(

--- a/manager/src/main/scala/org/broadinstitute/transporter/web/WebApi.scala
+++ b/manager/src/main/scala/org/broadinstitute/transporter/web/WebApi.scala
@@ -139,9 +139,18 @@ class WebApi(
         )
     }
 
+  private val postTransferRequestExample: TransferRequest = TransferRequest(
+    transferSchema.asExample, Option(0.toShort)
+  )
+
+  private val postBulkRequestExample: BulkRequest = BulkRequest(
+    List(postTransferRequestExample),
+    Option(postTransferRequestExample)
+  )
+
   private val submitBatchRoute: Route[BulkRequest, ApiError, RequestAck] =
     batchesBase.post
-      .in(jsonBody[BulkRequest].example(transferSchema.asExample))
+      .in(jsonBody[BulkRequest].example(postBulkRequestExample))
       .out(jsonBody[RequestAck])
       .errorOut(
         oneOf(

--- a/manager/src/test/scala/org/broadinstitute/transporter/transfer/config/TransferSchemaSpec.scala
+++ b/manager/src/test/scala/org/broadinstitute/transporter/transfer/config/TransferSchemaSpec.scala
@@ -157,4 +157,29 @@ class TransferSchemaSpec extends FlatSpec with Matchers with EitherValues {
     schema.validate(json"""["a", "b", "c", "d"]""").isValid shouldBe false
     schema.validate(json"{}").isValid shouldBe false
   }
+
+  it should "convert to an example Json format" in {
+    val theJson = json"""{
+                       "title": "Example schema",
+                       "type": "object",
+                       "properties": {
+                          "prop1": {
+                              "description": "First example property",
+                              "type": "string"
+                              },
+                          "prop2": {
+                              "description": "Second example property",
+                              "type": "string"
+                              }
+                          },
+                       "required": ["prop1", "prop2"]
+                       }"""
+    val schema = theJson.as[TransferSchema].right.value
+    val targetJson =
+      json"""{
+          "prop1": "string",
+          "prop2": "string"
+          }"""
+    schema.asExample shouldBe targetJson
+  }
 }

--- a/setup-local-env
+++ b/setup-local-env
@@ -60,7 +60,7 @@ function generate_configs () {
     '  kafka.topics {'
     "    request-topic: \"${KAFKA_TOPIC_PREFIX}.requests\""
     "    progress-topic: \"${KAFKA_TOPIC_PREFIX}.progress\""
-    "    results-topic: \"${KAFKA_TOPIC_PREFIX}.results\""
+    "    result-topic: \"${KAFKA_TOPIC_PREFIX}.results\""
     '  }'
     '}'
   )
@@ -69,7 +69,7 @@ function generate_configs () {
     'org.broadinstitute.transporter.kafka.topics {'
     "  request-topic: \"${KAFKA_TOPIC_PREFIX}.requests\""
     "  progress-topic: \"${KAFKA_TOPIC_PREFIX}.progress\""
-    "  results-topic: \"${KAFKA_TOPIC_PREFIX}.results\""
+    "  result-topic: \"${KAFKA_TOPIC_PREFIX}.results\""
     '}'
   )
 


### PR DESCRIPTION
- Make the json parameter of TransferSchema not private
- Pass the above json parameter of the schema to the WebApi in TransporterManager
- Update WebApi to take the json as a parameter and use it to create an example body for the batch post request endpoint
- update setup-local-env to fix typo of "results" -> "result" for the kafka topic name