### PR TITLE
Index request_id in the transfers table

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,13 +20,13 @@ pipeline {
                 sh 'sbt Compile/compile Test/compile'
             }
         }
-        /*stage('Test') {
+        stage('Test') {
             steps {
                 sh 'sbt test'
             }
-        }*/
+        }
         stage('Publish') {
-            //when { branch 'master' }
+            when { branch 'master' }
             environment {
                 PATH = "${tool('gcloud')}:${tool('vault')}:${tool('jq')}:$PATH"
                 // Some wiring is broken between the custom-tools plugin and

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,13 +20,13 @@ pipeline {
                 sh 'sbt Compile/compile Test/compile'
             }
         }
-        stage('Test') {
+        /*stage('Test') {
             steps {
                 sh 'sbt test'
             }
-        }
+        }*/
         stage('Publish') {
-            when { branch 'master' }
+            //when { branch 'master' }
             environment {
                 PATH = "${tool('gcloud')}:${tool('vault')}:${tool('jq')}:$PATH"
                 // Some wiring is broken between the custom-tools plugin and

--- a/manager/db-migrations/src/main/resources/changelog.xml
+++ b/manager/db-migrations/src/main/resources/changelog.xml
@@ -17,4 +17,5 @@
     <include file="changesets/13-add-request-received-time.xml" relativeToChangelogFile="true" />
     <include file="changesets/14-add-request-priority.xml" relativeToChangelogFile="true" />
     <include file="changesets/15-add-expanded-transfer-status.xml" relativeToChangelogFile="true" />
+    <include file="changesets/16-index-request-id.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/manager/db-migrations/src/main/resources/changesets/16-index-request-id.xml
+++ b/manager/db-migrations/src/main/resources/changesets/16-index-request-id.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="16" author="danmoran">
+
+        <createIndex tableName="transfers" indexName="transfers_request_id">
+            <column name="request_id" />
+        </createIndex>
+
+        <rollback>
+            <dropIndex tableName="transfers" indexName="transfers_request_id" />
+        </rollback>
+
+    </changeSet>
+
+</databaseChangeLog>

--- a/manager/src/main/resources/logback.xml
+++ b/manager/src/main/resources/logback.xml
@@ -5,11 +5,6 @@
         </encoder>
     </appender>
 
-    <!-- Use debug level for our own messages so we can eyeball logs during testing. -->
-    <logger name="org.broadinstitute" level="DEBUG" additivity="false">
-        <appender-ref ref="STDOUT" />
-    </logger>
-
     <root level="INFO">
         <appender-ref ref="STDOUT" />
     </root>

--- a/manager/src/main/resources/reference.conf
+++ b/manager/src/main/resources/reference.conf
@@ -20,9 +20,13 @@ org.broadinstitute.transporter {
 
     timeouts {
       connection-timeout: 60s
+      connection-timeout: ${?DB_CONNECTION_TIMEOUT}
       max-connection-lifetime: 30s
+      max-connection-lifetime: ${?DB_MAX_CONNECTION_LIFETIME}
       connection-validation-timeout: 1s
+      connection-validation-timeout: ${?DB_CONNECTION_VALIDATION_TIMEOUT}
       leak-detection-threshold: 10s
+      leak-detection-threshold: ${?DB_LEAK_DETECTION_THRESHOLD}
     }
   }
 


### PR DESCRIPTION
Turns out postgres doesn't auto-index the referring side of foreign keys! Not having this was causing every join between the `transfers` and `transfer_requests` table to scan all of `transfers`.